### PR TITLE
fix: Resolve test skips — router ordering and resilient Galaxy test

### DIFF
--- a/backend/app/api/endpoints/collaboration.py
+++ b/backend/app/api/endpoints/collaboration.py
@@ -38,6 +38,51 @@ from app.services.playbook_access_service import (
 router = APIRouter(prefix="/playbooks", tags=["collaboration"])
 
 
+# === Shared With Me Endpoint ===
+# NOTE: Must be defined BEFORE /{playbook_id} routes to avoid being
+# shadowed by the path parameter catch-all.
+
+@router.get("/shared-with-me", response_model=SharedPlaybooksListResponse)
+async def list_shared_with_me(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db)
+):
+    """
+    List playbooks that have been shared with the current user.
+
+    Returns:
+        List of shared playbooks with owner info and user's role
+    """
+    # Get shares for current user with playbook and owner info
+    shares_result = await db.execute(
+        select(PlaybookShare, Playbook, User)
+        .join(Playbook, PlaybookShare.playbook_id == Playbook.id)
+        .join(User, Playbook.owner_id == User.id)
+        .where(PlaybookShare.user_id == current_user.id)
+        .order_by(Playbook.updated_at.desc())
+    )
+    results = shares_result.all()
+
+    playbooks = []
+    for share, playbook, owner in results:
+        playbooks.append(SharedPlaybookResponse(
+            id=playbook.id,
+            name=playbook.name,
+            description=playbook.description,
+            owner_id=playbook.owner_id,
+            owner_username=owner.username,
+            role=share.role,
+            version=playbook.version,
+            created_at=playbook.created_at,
+            updated_at=playbook.updated_at
+        ))
+
+    return SharedPlaybooksListResponse(
+        playbooks=playbooks,
+        total=len(playbooks)
+    )
+
+
 # === Share Endpoints ===
 
 @router.post("/{playbook_id}/shares", response_model=ShareResponse, status_code=status.HTTP_201_CREATED)
@@ -305,49 +350,6 @@ async def delete_share(
     await db.commit()
 
     return None
-
-
-# === Shared With Me Endpoint ===
-
-@router.get("/shared-with-me", response_model=SharedPlaybooksListResponse)
-async def list_shared_with_me(
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db)
-):
-    """
-    List playbooks that have been shared with the current user.
-
-    Returns:
-        List of shared playbooks with owner info and user's role
-    """
-    # Get shares for current user with playbook and owner info
-    shares_result = await db.execute(
-        select(PlaybookShare, Playbook, User)
-        .join(Playbook, PlaybookShare.playbook_id == Playbook.id)
-        .join(User, Playbook.owner_id == User.id)
-        .where(PlaybookShare.user_id == current_user.id)
-        .order_by(Playbook.updated_at.desc())
-    )
-    results = shares_result.all()
-
-    playbooks = []
-    for share, playbook, owner in results:
-        playbooks.append(SharedPlaybookResponse(
-            id=playbook.id,
-            name=playbook.name,
-            description=playbook.description,
-            owner_id=playbook.owner_id,
-            owner_username=owner.username,
-            role=share.role,
-            version=playbook.version,
-            created_at=playbook.created_at,
-            updated_at=playbook.updated_at
-        ))
-
-    return SharedPlaybooksListResponse(
-        playbooks=playbooks,
-        total=len(playbooks)
-    )
 
 
 # === Audit Log Endpoints ===

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -13,14 +13,16 @@ from app.version import __version__
 api_router = APIRouter()
 
 # Include all endpoint routers
+# NOTE: collaboration must come before playbooks so that /shared-with-me
+# is matched before the /{playbook_id} catch-all in playbooks.router.
 api_router.include_router(auth.router)
+api_router.include_router(collaboration.router)  # Playbook sharing and collaboration
 api_router.include_router(playbooks.router)
 api_router.include_router(admin.router)
 api_router.include_router(common.router)
 api_router.include_router(user_favorites.router)
 api_router.include_router(admin_configuration.router)
 api_router.include_router(ansible.router)  # Ansible documentation API
-api_router.include_router(collaboration.router)  # Playbook sharing and collaboration
 api_router.include_router(variable_types.router)  # Custom variable types management
 api_router.include_router(galaxy_roles.router)  # Galaxy roles API (v1 standalone + v3 collection)
 api_router.include_router(playbook_export.router)  # Diagram export (ABD, Mermaid, SVG)

--- a/backend/tests/test_galaxy_roles_service.py
+++ b/backend/tests/test_galaxy_roles_service.py
@@ -334,13 +334,16 @@ class TestGalaxyRolesService:
     # ========================================
 
     @pytest.mark.asyncio
-    @pytest.mark.skip(reason="Integration test - requires network access")
     async def test_real_api_call(self, service):
-        """Integration test - uncomment to test real API"""
-        result = await service.get_standalone_roles(
-            search="docker",
-            page_size=5
-        )
+        """Integration test — calls the real Galaxy API (skips on network failure)."""
+        try:
+            result = await service.get_standalone_roles(
+                search="docker",
+                page_size=5
+            )
+        except Exception as exc:
+            pytest.skip(f"Galaxy API unreachable: {exc}")
+        finally:
+            await service.close_session()
         assert result["count"] > 0
         assert len(result["results"]) <= 5
-        await service.close_session()


### PR DESCRIPTION
## Summary
- Fix `/shared-with-me` route shadowed by `/{playbook_id}` catch-all by reordering route definitions in `collaboration.py` and router inclusion order in `router.py`
- Make Galaxy API integration test resilient: skip gracefully on network failure instead of unconditional `@pytest.mark.skip`

## Changes
- `backend/app/api/endpoints/collaboration.py` — move `/shared-with-me` endpoint before `/{playbook_id}` routes
- `backend/app/api/router.py` — include `collaboration.router` before `playbooks.router`
- `backend/tests/test_galaxy_roles_service.py` — wrap real API call in try/except, `pytest.skip()` on failure

## Test plan
- [ ] `test_shared_with_me` now passes (was permanently skipped)
- [ ] `test_real_api_call` passes with network, skips gracefully without
- [ ] No regressions on existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)