### PR TITLE
feat: Project list, home page, and project workbench layout

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,9 @@
 import { CssBaseline } from '@mui/material'
 import { Routes, Route, Navigate } from 'react-router-dom'
 import MainLayout from './components/layout/MainLayout'
+import ProjectLayout from './components/layout/ProjectLayout'
 import AccountsManagementPage from './pages/AccountsManagementPage'
+import HomePage from './pages/HomePage'
 import LoginPage from './pages/LoginPage'
 import PrivateRoute from './components/auth/PrivateRoute'
 
@@ -13,8 +15,22 @@ function App() {
         {/* Login page - public */}
         <Route path="/login" element={<LoginPage />} />
 
-        {/* Main workspace - protected */}
+        {/* Home page - protected */}
         <Route path="/" element={
+          <PrivateRoute>
+            <HomePage />
+          </PrivateRoute>
+        } />
+
+        {/* Project workbench - protected */}
+        <Route path="/projects/:projectId" element={
+          <PrivateRoute>
+            <ProjectLayout />
+          </PrivateRoute>
+        } />
+
+        {/* Standalone playbook editor - protected */}
+        <Route path="/playbooks/:playbookId" element={
           <PrivateRoute>
             <MainLayout />
           </PrivateRoute>

--- a/frontend/src/components/home/CreateProjectDialog.tsx
+++ b/frontend/src/components/home/CreateProjectDialog.tsx
@@ -1,0 +1,93 @@
+import React, { useState } from 'react'
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+} from '@mui/material'
+import { useTranslation } from 'react-i18next'
+import { useNavigate } from 'react-router-dom'
+import { useProjectStore } from '../../stores/projectStore'
+
+interface CreateProjectDialogProps {
+  open: boolean
+  onClose: () => void
+}
+
+const CreateProjectDialog: React.FC<CreateProjectDialogProps> = ({ open, onClose }) => {
+  const { t } = useTranslation('project')
+  const { t: tc } = useTranslation('common')
+  const navigate = useNavigate()
+  const createProject = useProjectStore(s => s.createProject)
+
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const handleCreate = async () => {
+    if (!name.trim()) return
+    setIsSubmitting(true)
+    try {
+      const project = await createProject({
+        name: name.trim(),
+        description: description.trim() || undefined,
+      })
+      onClose()
+      setName('')
+      setDescription('')
+      navigate(`/projects/${project.id}`)
+    } catch {
+      // Error is handled by the store
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleClose = () => {
+    onClose()
+    setName('')
+    setDescription('')
+  }
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+      <DialogTitle>{t('newProject')}</DialogTitle>
+      <DialogContent>
+        <TextField
+          autoFocus
+          margin="dense"
+          label={t('projectName')}
+          fullWidth
+          variant="outlined"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter' && name.trim()) handleCreate() }}
+        />
+        <TextField
+          margin="dense"
+          label={t('description')}
+          fullWidth
+          variant="outlined"
+          multiline
+          rows={3}
+          value={description}
+          onChange={e => setDescription(e.target.value)}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>{tc('cancel')}</Button>
+        <Button
+          onClick={handleCreate}
+          variant="contained"
+          disabled={!name.trim() || isSubmitting}
+        >
+          {t('create')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default CreateProjectDialog

--- a/frontend/src/components/home/ProjectCard.tsx
+++ b/frontend/src/components/home/ProjectCard.tsx
@@ -1,0 +1,98 @@
+import React from 'react'
+import {
+  Card,
+  CardContent,
+  CardActionArea,
+  Typography,
+  Box,
+  Chip,
+} from '@mui/material'
+import FolderIcon from '@mui/icons-material/Folder'
+import ShareIcon from '@mui/icons-material/Share'
+import { useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { Project } from '../../services/projectService'
+
+interface ProjectCardProps {
+  project: Project
+}
+
+const ProjectCard: React.FC<ProjectCardProps> = ({ project }) => {
+  const navigate = useNavigate()
+  const { t } = useTranslation('project')
+
+  const updatedDate = new Date(project.updated_at)
+  const relativeTime = getRelativeTime(updatedDate)
+
+  return (
+    <Card variant="outlined" sx={{ height: '100%' }}>
+      <CardActionArea
+        onClick={() => navigate(`/projects/${project.id}`)}
+        sx={{ height: '100%' }}
+      >
+        <CardContent>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+            <FolderIcon color="primary" />
+            <Typography variant="h6" noWrap sx={{ flex: 1 }}>
+              {project.name}
+            </Typography>
+          </Box>
+
+          {project.description && (
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{
+                mb: 1,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                display: '-webkit-box',
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: 'vertical',
+              }}
+            >
+              {project.description}
+            </Typography>
+          )}
+
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 1 }}>
+            <Typography variant="caption" color="text.secondary">
+              {t('lastEdited')}: {relativeTime}
+            </Typography>
+            {project.is_shared && (
+              <Chip
+                icon={<ShareIcon />}
+                label={project.user_role}
+                size="small"
+                variant="outlined"
+                color="info"
+              />
+            )}
+          </Box>
+
+          {project.owner_username && !project.is_shared && (
+            <Typography variant="caption" color="text.secondary">
+              {project.owner_username}
+            </Typography>
+          )}
+        </CardContent>
+      </CardActionArea>
+    </Card>
+  )
+}
+
+function getRelativeTime(date: Date): string {
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffMins = Math.floor(diffMs / 60000)
+  const diffHours = Math.floor(diffMs / 3600000)
+  const diffDays = Math.floor(diffMs / 86400000)
+
+  if (diffMins < 1) return 'just now'
+  if (diffMins < 60) return `${diffMins}m ago`
+  if (diffHours < 24) return `${diffHours}h ago`
+  if (diffDays < 7) return `${diffDays}d ago`
+  return date.toLocaleDateString()
+}
+
+export default ProjectCard

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -45,6 +45,7 @@ import ErrorIcon from '@mui/icons-material/Error'
 import ArticleIcon from '@mui/icons-material/Article'
 import LinkOffIcon from '@mui/icons-material/LinkOff'
 import ShareIcon from '@mui/icons-material/Share'
+import HomeIcon from '@mui/icons-material/Home'
 import { useTranslation } from 'react-i18next'
 import { getHttpClient } from '../../utils/httpClient'
 import PresenceIndicator from '../collaboration/PresenceIndicator'
@@ -285,6 +286,17 @@ const AppHeader: React.FC<AppHeaderProps> = ({
               <CircularProgress size={16} sx={{ color: 'white', ml: 1 }} />
             )}
           </Box>
+        </Tooltip>
+
+        {/* Home button */}
+        <Tooltip title={t('back', { defaultValue: 'Home' })} placement="bottom">
+          <IconButton
+            onClick={() => navigate('/')}
+            size="small"
+            sx={{ color: 'white', mr: 'var(--spacing-xs, 4px)' }}
+          >
+            <HomeIcon fontSize="small" />
+          </IconButton>
         </Tooltip>
 
         {/* Center - Playbook Info */}

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -4,6 +4,7 @@ import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
 import ExpandLessIcon from '@mui/icons-material/ExpandLess'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import React, { useState, useRef, useEffect } from 'react'
+import { useParams } from 'react-router-dom'
 import AppHeader from './AppHeader'
 import { useCollaboration } from '../../contexts/CollaborationContext'
 import { useCollaborationSync } from '../../hooks/useCollaborationSync'
@@ -16,6 +17,8 @@ import SystemZone from '../zones/SystemZone'
 import PlaybookManagerDialog from '../dialogs/PlaybookManagerDialog'
 
 const MainLayout = () => {
+  const { playbookId: routePlaybookId } = useParams<{ playbookId: string }>()
+
   // Local UI state (zone widths, collapse states, resize flags)
   const [systemZoneHeight, setSystemZoneHeight] = useState(200)
   const [modulesZoneWidth, setModulesZoneWidth] = useState(280)
@@ -76,6 +79,15 @@ const MainLayout = () => {
     sendBlockCollapse,
     sendSectionCollapse
   }
+
+  // Auto-load playbook from route params
+  const loadPlaybookRef = useRef(loadPlaybook)
+  useEffect(() => { loadPlaybookRef.current = loadPlaybook })
+  useEffect(() => {
+    if (routePlaybookId && routePlaybookId !== currentPlaybookId) {
+      loadPlaybookRef.current(routePlaybookId)
+    }
+  }, [routePlaybookId])
 
   // Apply received collaboration updates directly to store
   useEffect(() => {

--- a/frontend/src/components/layout/ProjectLayout.tsx
+++ b/frontend/src/components/layout/ProjectLayout.tsx
@@ -1,0 +1,256 @@
+import React, { useEffect, useState } from 'react'
+import {
+  Box,
+  Tabs,
+  Tab,
+  Typography,
+  CircularProgress,
+  IconButton,
+  Tooltip,
+} from '@mui/material'
+import ChevronRightIcon from '@mui/icons-material/ChevronRight'
+import ExpandLessIcon from '@mui/icons-material/ExpandLess'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import { useParams } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { useProjectStore } from '../../stores/projectStore'
+import ProjectHeader from '../project/ProjectHeader'
+import ProjectTree from '../project/ProjectTree'
+import ModulesZoneCached from '../zones/ModulesZoneCached'
+import SystemZone from '../zones/SystemZone'
+
+const ProjectLayout: React.FC = () => {
+  const { projectId } = useParams<{ projectId: string }>()
+  const { t } = useTranslation('project')
+
+  const currentProject = useProjectStore(s => s.currentProject)
+  const isLoading = useProjectStore(s => s.isLoading)
+  const fetchProject = useProjectStore(s => s.fetchProject)
+  const fetchArtifacts = useProjectStore(s => s.fetchArtifacts)
+  const clearCurrentProject = useProjectStore(s => s.clearCurrentProject)
+
+  // Left panel state
+  const [leftTab, setLeftTab] = useState(0)
+  const [leftPanelWidth, setLeftPanelWidth] = useState(280)
+  const [isLeftCollapsed, setIsLeftCollapsed] = useState(false)
+  const [isResizingLeft, setIsResizingLeft] = useState(false)
+
+  // Bottom panel state
+  const [systemZoneHeight, setSystemZoneHeight] = useState(200)
+  const [isSystemCollapsed, setIsSystemCollapsed] = useState(true)
+  const [isResizingSystem, setIsResizingSystem] = useState(false)
+
+  useEffect(() => {
+    if (projectId) {
+      fetchProject(projectId)
+      fetchArtifacts(projectId)
+    }
+    return () => { clearCurrentProject() }
+  }, [projectId])
+
+  // Resize handlers
+  const handleLeftMouseDown = () => setIsResizingLeft(true)
+  const handleSystemMouseDown = () => setIsResizingSystem(true)
+
+  const handleMouseMove = (e: MouseEvent) => {
+    if (isResizingLeft) {
+      const newWidth = e.clientX
+      if (newWidth >= 200 && newWidth <= 500) setLeftPanelWidth(newWidth)
+    } else if (isResizingSystem) {
+      const newHeight = window.innerHeight - e.clientY
+      if (newHeight >= 100 && newHeight <= 600) setSystemZoneHeight(newHeight)
+    }
+  }
+
+  const handleMouseUp = () => {
+    setIsResizingLeft(false)
+    setIsResizingSystem(false)
+  }
+
+  React.useEffect(() => {
+    if (isResizingLeft || isResizingSystem) {
+      document.addEventListener('mousemove', handleMouseMove as any)
+      document.addEventListener('mouseup', handleMouseUp)
+    } else {
+      document.removeEventListener('mousemove', handleMouseMove as any)
+      document.removeEventListener('mouseup', handleMouseUp)
+    }
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove as any)
+      document.removeEventListener('mouseup', handleMouseUp)
+    }
+  }, [isResizingLeft, isResizingSystem])
+
+  if (isLoading && !currentProject) {
+    return (
+      <Box sx={{ height: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <CircularProgress />
+      </Box>
+    )
+  }
+
+  return (
+    <Box sx={{ height: '100vh', display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+      {/* Header */}
+      <ProjectHeader projectName={currentProject?.name || '...'} />
+
+      {/* Main content area */}
+      <Box sx={{ flex: 1, display: 'flex', overflow: 'hidden', minHeight: 0 }}>
+        {/* Left panel */}
+        {!isLeftCollapsed && (
+          <Box
+            sx={{
+              width: `${leftPanelWidth}px`,
+              borderRight: '1px solid',
+              borderColor: 'divider',
+              flexShrink: 0,
+              overflow: 'hidden',
+              display: 'flex',
+              flexDirection: 'column',
+              position: 'relative',
+            }}
+          >
+            <Tabs
+              value={leftTab}
+              onChange={(_e, v) => setLeftTab(v)}
+              variant="fullWidth"
+              sx={{ minHeight: 36, '& .MuiTab-root': { minHeight: 36, py: 0.5, fontSize: '0.8rem' } }}
+            >
+              <Tab label={t('projectTree')} />
+              <Tab label={t('modules')} />
+            </Tabs>
+
+            <Box sx={{ flex: 1, overflow: 'auto' }}>
+              {leftTab === 0 && <ProjectTree />}
+              {leftTab === 1 && <ModulesZoneCached />}
+            </Box>
+
+            {/* Resize handle */}
+            <Box
+              onMouseDown={handleLeftMouseDown}
+              sx={{
+                position: 'absolute',
+                top: 0, right: 0, bottom: 0,
+                width: '6px',
+                cursor: 'ew-resize',
+                bgcolor: isResizingLeft ? 'primary.main' : 'transparent',
+                '&:hover': { bgcolor: 'primary.light' },
+                transition: 'background-color 0.2s',
+                zIndex: 10,
+              }}
+            >
+              <Box sx={{
+                position: 'absolute',
+                top: '50%', left: '50%',
+                transform: 'translate(-50%, -50%)',
+                width: '3px', height: '40px',
+                borderRadius: '2px',
+                bgcolor: isResizingLeft ? 'white' : '#999',
+              }} />
+            </Box>
+          </Box>
+        )}
+
+        {/* Center area */}
+        <Box sx={{ flex: 1, overflow: 'auto', minWidth: 0, position: 'relative' }}>
+          {isLeftCollapsed && (
+            <Tooltip title={t('projectTree')} placement="right">
+              <IconButton
+                onClick={() => setIsLeftCollapsed(false)}
+                sx={{
+                  position: 'absolute', top: 8, left: 8, zIndex: 1000,
+                  bgcolor: 'background.paper', boxShadow: 2,
+                  '&:hover': { bgcolor: 'primary.light' },
+                }}
+              >
+                <ChevronRightIcon />
+              </IconButton>
+            </Tooltip>
+          )}
+
+          <Box sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            height: '100%',
+            p: 4,
+          }}>
+            <Typography variant="body1" color="text.secondary" sx={{ textAlign: 'center' }}>
+              {t('selectArtifact')}
+            </Typography>
+          </Box>
+        </Box>
+      </Box>
+
+      {/* System zone (bottom) */}
+      {!isSystemCollapsed ? (
+        <Box
+          sx={{
+            height: `${systemZoneHeight}px`,
+            borderTop: '1px solid',
+            borderColor: 'divider',
+            flexShrink: 0,
+            position: 'relative',
+          }}
+        >
+          <Box
+            onMouseDown={handleSystemMouseDown}
+            sx={{
+              position: 'absolute',
+              top: 0, left: 0, right: 0,
+              height: '6px',
+              cursor: 'ns-resize',
+              bgcolor: isResizingSystem ? 'primary.main' : 'transparent',
+              '&:hover': { bgcolor: 'primary.light' },
+              transition: 'background-color 0.2s',
+              zIndex: 10,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <Box sx={{ width: '40px', height: '3px', borderRadius: '2px', bgcolor: isResizingSystem ? 'white' : '#999' }} />
+            <Tooltip title={t('modules')} placement="top">
+              <IconButton
+                size="small"
+                onClick={() => setIsSystemCollapsed(true)}
+                sx={{
+                  position: 'absolute', right: 8,
+                  bgcolor: 'background.paper', boxShadow: 1,
+                  '&:hover': { bgcolor: 'primary.light' },
+                }}
+              >
+                <ExpandMoreIcon />
+              </IconButton>
+            </Tooltip>
+          </Box>
+          <SystemZone />
+        </Box>
+      ) : (
+        <Box
+          sx={{
+            height: '30px',
+            borderTop: '1px solid',
+            borderColor: 'divider',
+            flexShrink: 0,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            bgcolor: 'background.paper',
+            cursor: 'pointer',
+            '&:hover': { bgcolor: 'action.hover' },
+          }}
+          onClick={() => setIsSystemCollapsed(false)}
+        >
+          <Tooltip title="Show System Zone" placement="top">
+            <IconButton size="small">
+              <ExpandLessIcon />
+            </IconButton>
+          </Tooltip>
+        </Box>
+      )}
+    </Box>
+  )
+}
+
+export default ProjectLayout

--- a/frontend/src/components/project/ProjectHeader.tsx
+++ b/frontend/src/components/project/ProjectHeader.tsx
@@ -1,0 +1,129 @@
+import React, { useState } from 'react'
+import {
+  AppBar,
+  Toolbar,
+  Typography,
+  Box,
+  IconButton,
+  Avatar,
+  Menu,
+  MenuItem,
+  ListItemIcon,
+  ListItemText,
+  Chip,
+  Divider,
+  Tooltip,
+} from '@mui/material'
+import ArrowBackIcon from '@mui/icons-material/ArrowBack'
+import LogoutIcon from '@mui/icons-material/Logout'
+import Brightness4Icon from '@mui/icons-material/Brightness4'
+import Brightness7Icon from '@mui/icons-material/Brightness7'
+import SettingsBrightnessIcon from '@mui/icons-material/SettingsBrightness'
+import LanguageIcon from '@mui/icons-material/Language'
+import { useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { useAuth } from '../../contexts/AuthContext'
+import { useTheme } from '../../contexts/ThemeContext'
+
+interface ProjectHeaderProps {
+  projectName: string
+}
+
+const ProjectHeader: React.FC<ProjectHeaderProps> = ({ projectName }) => {
+  const navigate = useNavigate()
+  const { t } = useTranslation('project')
+  const { t: tc } = useTranslation('common')
+  const { i18n } = useTranslation()
+  const { user, logout } = useAuth()
+  const { themeMode, darkMode, cycleThemeMode } = useTheme()
+  const [userMenuAnchor, setUserMenuAnchor] = useState<null | HTMLElement>(null)
+
+  const handleLogout = async () => {
+    setUserMenuAnchor(null)
+    await logout()
+    navigate('/login')
+  }
+
+  return (
+    <AppBar position="static" color="default" elevation={1}>
+      <Toolbar variant="dense">
+        <Tooltip title={t('backToHome')}>
+          <IconButton edge="start" onClick={() => navigate('/')} sx={{ mr: 1 }}>
+            <ArrowBackIcon />
+          </IconButton>
+        </Tooltip>
+
+        <Typography variant="body1" color="text.secondary" sx={{ mr: 0.5 }}>
+          AF
+        </Typography>
+        <Typography variant="body1" color="text.secondary" sx={{ mr: 0.5 }}>
+          &gt;
+        </Typography>
+        <Typography variant="body1" fontWeight="bold" noWrap sx={{ flex: 1 }}>
+          {projectName}
+        </Typography>
+
+        {user && (
+          <Box>
+            <IconButton onClick={(e) => setUserMenuAnchor(e.currentTarget)}>
+              <Avatar sx={{ width: 28, height: 28, fontSize: '0.8rem', bgcolor: 'primary.main' }}>
+                {user.username?.charAt(0).toUpperCase()}
+              </Avatar>
+            </IconButton>
+            <Menu
+              anchorEl={userMenuAnchor}
+              open={Boolean(userMenuAnchor)}
+              onClose={() => setUserMenuAnchor(null)}
+            >
+              <MenuItem disabled>
+                <ListItemText primary={user.username} />
+              </MenuItem>
+              <Divider />
+
+              <MenuItem onClick={() => { cycleThemeMode() }}>
+                <ListItemIcon>
+                  {themeMode === 'light' && <Brightness7Icon fontSize="small" />}
+                  {themeMode === 'dark' && <Brightness4Icon fontSize="small" />}
+                  {themeMode === 'system' && <SettingsBrightnessIcon fontSize="small" />}
+                </ListItemIcon>
+                <ListItemText
+                  primary={
+                    themeMode === 'light' ? tc('lightMode') :
+                    themeMode === 'dark' ? tc('darkMode') :
+                    tc('systemAuto')
+                  }
+                />
+                <Chip
+                  label={themeMode === 'light' ? 'Light' : themeMode === 'dark' ? 'Dark' : 'Auto'}
+                  size="small" variant="outlined"
+                  sx={{ ml: 1, fontSize: '0.7rem', height: 20 }}
+                />
+              </MenuItem>
+
+              <MenuItem onClick={() => {
+                const next = i18n.language?.startsWith('fr') ? 'en' : 'fr'
+                i18n.changeLanguage(next)
+              }}>
+                <ListItemIcon><LanguageIcon fontSize="small" /></ListItemIcon>
+                <ListItemText primary={tc('language')} />
+                <Chip
+                  label={i18n.language?.startsWith('fr') ? 'FR' : 'EN'}
+                  size="small" variant="outlined"
+                  sx={{ ml: 1, fontSize: '0.7rem', height: 20 }}
+                />
+              </MenuItem>
+
+              <Divider />
+              <MenuItem onClick={handleLogout}>
+                <ListItemIcon><LogoutIcon fontSize="small" /></ListItemIcon>
+                <ListItemText>{tc('logout')}</ListItemText>
+              </MenuItem>
+            </Menu>
+          </Box>
+        )}
+      </Toolbar>
+    </AppBar>
+  )
+}
+
+export default ProjectHeader

--- a/frontend/src/components/project/ProjectTree.tsx
+++ b/frontend/src/components/project/ProjectTree.tsx
@@ -1,0 +1,198 @@
+import React, { useState } from 'react'
+import {
+  Box,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Collapse,
+  Typography,
+  Chip,
+  Snackbar,
+  Alert,
+} from '@mui/material'
+import ExpandLess from '@mui/icons-material/ExpandLess'
+import ExpandMore from '@mui/icons-material/ExpandMore'
+import DescriptionIcon from '@mui/icons-material/Description'
+import BuildIcon from '@mui/icons-material/Build'
+import StorageIcon from '@mui/icons-material/Storage'
+import TuneIcon from '@mui/icons-material/Tune'
+import CodeIcon from '@mui/icons-material/Code'
+import LibraryBooksIcon from '@mui/icons-material/LibraryBooks'
+import ExtensionIcon from '@mui/icons-material/Extension'
+import SettingsIcon from '@mui/icons-material/Settings'
+import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile'
+import { useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { useProjectStore } from '../../stores/projectStore'
+import { ProjectArtifact } from '../../services/projectService'
+import { playbookService } from '../../services/playbookService'
+
+const ARTIFACT_TYPE_CONFIG: Record<string, { icon: React.ReactElement; order: number }> = {
+  playbook: { icon: <DescriptionIcon fontSize="small" />, order: 0 },
+  role: { icon: <BuildIcon fontSize="small" />, order: 1 },
+  inventory: { icon: <StorageIcon fontSize="small" />, order: 2 },
+  variable_file: { icon: <TuneIcon fontSize="small" />, order: 3 },
+  template: { icon: <CodeIcon fontSize="small" />, order: 4 },
+  collection_requirements: { icon: <LibraryBooksIcon fontSize="small" />, order: 5 },
+  custom_module: { icon: <ExtensionIcon fontSize="small" />, order: 6 },
+  ansible_cfg: { icon: <SettingsIcon fontSize="small" />, order: 7 },
+  file: { icon: <InsertDriveFileIcon fontSize="small" />, order: 8 },
+}
+
+const ProjectTree: React.FC = () => {
+  const { t } = useTranslation('project')
+  const navigate = useNavigate()
+  const artifacts = useProjectStore(s => s.artifacts)
+  const currentProject = useProjectStore(s => s.currentProject)
+
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set(['playbook']))
+  const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity: 'info' | 'warning' }>({
+    open: false, message: '', severity: 'info',
+  })
+
+  // Group artifacts by type
+  const grouped = artifacts.reduce<Record<string, ProjectArtifact[]>>((acc, artifact) => {
+    const type = artifact.artifact_type
+    if (!acc[type]) acc[type] = []
+    acc[type].push(artifact)
+    return acc
+  }, {})
+
+  // Sort groups by configured order
+  const sortedTypes = Object.keys(grouped).sort((a, b) => {
+    const orderA = ARTIFACT_TYPE_CONFIG[a]?.order ?? 99
+    const orderB = ARTIFACT_TYPE_CONFIG[b]?.order ?? 99
+    return orderA - orderB
+  })
+
+  const toggleGroup = (type: string) => {
+    setExpandedGroups(prev => {
+      const next = new Set(prev)
+      if (next.has(type)) next.delete(type)
+      else next.add(type)
+      return next
+    })
+  }
+
+  const handleArtifactDoubleClick = async (artifact: ProjectArtifact) => {
+    if (artifact.artifact_type === 'playbook') {
+      // Try to find matching playbook by searching user's playbooks
+      try {
+        const playbooks = await playbookService.listPlaybooks()
+        // Find playbook linked to this project artifact
+        // The artifact content may contain a playbook_id reference, or match by name
+        const matchingPlaybook = playbooks.find(p =>
+          p.id === artifact.content?.playbook_id ||
+          (currentProject && p.name === artifact.path)
+        )
+        if (matchingPlaybook) {
+          navigate(`/playbooks/${matchingPlaybook.id}`)
+        } else {
+          setSnackbar({
+            open: true,
+            message: 'No linked playbook found for this artifact.',
+            severity: 'info',
+          })
+        }
+      } catch {
+        setSnackbar({
+          open: true,
+          message: 'Failed to load playbooks.',
+          severity: 'warning',
+        })
+      }
+    } else {
+      setSnackbar({
+        open: true,
+        message: t('comingSoon'),
+        severity: 'info',
+      })
+    }
+  }
+
+  const getTypeIcon = (type: string) => {
+    return ARTIFACT_TYPE_CONFIG[type]?.icon || <InsertDriveFileIcon fontSize="small" />
+  }
+
+  const getTypeLabel = (type: string): string => {
+    return t(`artifactTypes.${type}`, type)
+  }
+
+  if (artifacts.length === 0) {
+    return (
+      <Box sx={{ p: 2 }}>
+        <Typography variant="body2" color="text.secondary" sx={{ textAlign: 'center' }}>
+          {t('selectArtifact')}
+        </Typography>
+      </Box>
+    )
+  }
+
+  return (
+    <Box sx={{ overflow: 'auto' }}>
+      <List dense disablePadding>
+        {sortedTypes.map(type => {
+          const items = grouped[type]
+          const isExpanded = expandedGroups.has(type)
+
+          return (
+            <React.Fragment key={type}>
+              <ListItemButton onClick={() => toggleGroup(type)} sx={{ py: 0.5 }}>
+                <ListItemIcon sx={{ minWidth: 32 }}>
+                  {getTypeIcon(type)}
+                </ListItemIcon>
+                <ListItemText
+                  primary={
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                      <Typography variant="body2" fontWeight="bold">
+                        {getTypeLabel(type)}
+                      </Typography>
+                      <Chip label={items.length} size="small" sx={{ height: 18, fontSize: '0.7rem' }} />
+                    </Box>
+                  }
+                />
+                {isExpanded ? <ExpandLess /> : <ExpandMore />}
+              </ListItemButton>
+              <Collapse in={isExpanded} timeout="auto">
+                <List dense disablePadding>
+                  {items.map(artifact => (
+                    <ListItemButton
+                      key={artifact.id}
+                      sx={{ pl: 4, py: 0.25 }}
+                      onDoubleClick={() => handleArtifactDoubleClick(artifact)}
+                    >
+                      <ListItemText
+                        primary={
+                          <Typography variant="body2" noWrap>
+                            {artifact.path}
+                          </Typography>
+                        }
+                      />
+                    </ListItemButton>
+                  ))}
+                </List>
+              </Collapse>
+            </React.Fragment>
+          )
+        })}
+      </List>
+
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={4000}
+        onClose={() => setSnackbar(prev => ({ ...prev, open: false }))}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          severity={snackbar.severity}
+          onClose={() => setSnackbar(prev => ({ ...prev, open: false }))}
+        >
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </Box>
+  )
+}
+
+export default ProjectTree

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -8,6 +8,7 @@ import playbookEN from '../locales/en/playbook.json'
 import dialogsEN from '../locales/en/dialogs.json'
 import adminEN from '../locales/en/admin.json'
 import errorsEN from '../locales/en/errors.json'
+import projectEN from '../locales/en/project.json'
 
 import commonFR from '../locales/fr/common.json'
 import authFR from '../locales/fr/auth.json'
@@ -15,6 +16,7 @@ import playbookFR from '../locales/fr/playbook.json'
 import dialogsFR from '../locales/fr/dialogs.json'
 import adminFR from '../locales/fr/admin.json'
 import errorsFR from '../locales/fr/errors.json'
+import projectFR from '../locales/fr/project.json'
 
 i18n
   .use(LanguageDetector)
@@ -28,6 +30,7 @@ i18n
         dialogs: dialogsEN,
         admin: adminEN,
         errors: errorsEN,
+        project: projectEN,
       },
       fr: {
         common: commonFR,
@@ -36,11 +39,12 @@ i18n
         dialogs: dialogsFR,
         admin: adminFR,
         errors: errorsFR,
+        project: projectFR,
       },
     },
     fallbackLng: 'en',
     defaultNS: 'common',
-    ns: ['common', 'auth', 'playbook', 'dialogs', 'admin', 'errors'],
+    ns: ['common', 'auth', 'playbook', 'dialogs', 'admin', 'errors', 'project'],
     interpolation: {
       escapeValue: false,
     },

--- a/frontend/src/locales/en/project.json
+++ b/frontend/src/locales/en/project.json
@@ -1,0 +1,31 @@
+{
+  "projects": "Projects",
+  "standalonePlaybooks": "Standalone Playbooks",
+  "newProject": "New Project",
+  "newPlaybook": "New Standalone Playbook",
+  "projectName": "Project name",
+  "description": "Description",
+  "create": "Create",
+  "delete": "Delete",
+  "deleteConfirm": "Are you sure you want to delete \"{{name}}\"? All artifacts will be deleted.",
+  "noProjects": "No projects yet. Create your first project.",
+  "noPlaybooks": "No standalone playbooks.",
+  "lastEdited": "Last edited",
+  "sharedWith": "Shared with {{count}} user(s)",
+  "backToHome": "Back to home",
+  "projectTree": "Project",
+  "modules": "Modules",
+  "selectArtifact": "Select an artifact from the project tree to start editing.",
+  "comingSoon": "Editor for this artifact type is coming in a future release.",
+  "artifactTypes": {
+    "playbook": "Playbooks",
+    "role": "Roles",
+    "inventory": "Inventory",
+    "variable_file": "Variables",
+    "template": "Templates",
+    "collection_requirements": "Collections",
+    "custom_module": "Modules",
+    "ansible_cfg": "Configuration",
+    "file": "Files"
+  }
+}

--- a/frontend/src/locales/fr/project.json
+++ b/frontend/src/locales/fr/project.json
@@ -1,0 +1,31 @@
+{
+  "projects": "Projets",
+  "standalonePlaybooks": "Playbooks autonomes",
+  "newProject": "Nouveau projet",
+  "newPlaybook": "Nouveau playbook autonome",
+  "projectName": "Nom du projet",
+  "description": "Description",
+  "create": "Créer",
+  "delete": "Supprimer",
+  "deleteConfirm": "Êtes-vous sûr de vouloir supprimer \"{{name}}\" ? Tous les artefacts seront supprimés.",
+  "noProjects": "Aucun projet. Créez votre premier projet.",
+  "noPlaybooks": "Aucun playbook autonome.",
+  "lastEdited": "Dernière modification",
+  "sharedWith": "Partagé avec {{count}} utilisateur(s)",
+  "backToHome": "Retour à l'accueil",
+  "projectTree": "Projet",
+  "modules": "Modules",
+  "selectArtifact": "Sélectionnez un artefact dans l'arborescence du projet pour commencer l'édition.",
+  "comingSoon": "L'éditeur pour ce type d'artefact sera disponible dans une prochaine version.",
+  "artifactTypes": {
+    "playbook": "Playbooks",
+    "role": "Rôles",
+    "inventory": "Inventaire",
+    "variable_file": "Variables",
+    "template": "Templates",
+    "collection_requirements": "Collections",
+    "custom_module": "Modules",
+    "ansible_cfg": "Configuration",
+    "file": "Fichiers"
+  }
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,0 +1,304 @@
+import React, { useEffect, useState } from 'react'
+import {
+  AppBar,
+  Toolbar,
+  Typography,
+  Box,
+  Tabs,
+  Tab,
+  Fab,
+  Menu,
+  MenuItem,
+  ListItemIcon,
+  ListItemText,
+  Avatar,
+  IconButton,
+  Chip,
+  List,
+  ListItem,
+  ListItemButton,
+  CircularProgress,
+  Alert,
+  Divider,
+} from '@mui/material'
+import AddIcon from '@mui/icons-material/Add'
+import FolderIcon from '@mui/icons-material/Folder'
+import DescriptionIcon from '@mui/icons-material/Description'
+import LogoutIcon from '@mui/icons-material/Logout'
+import Brightness4Icon from '@mui/icons-material/Brightness4'
+import Brightness7Icon from '@mui/icons-material/Brightness7'
+import SettingsBrightnessIcon from '@mui/icons-material/SettingsBrightness'
+import LanguageIcon from '@mui/icons-material/Language'
+import SupervisorAccountIcon from '@mui/icons-material/SupervisorAccount'
+import { useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { useAuth } from '../contexts/AuthContext'
+import { useTheme } from '../contexts/ThemeContext'
+import { useProjectStore } from '../stores/projectStore'
+import { playbookService, Playbook } from '../services/playbookService'
+import ProjectCard from '../components/home/ProjectCard'
+import CreateProjectDialog from '../components/home/CreateProjectDialog'
+
+const HomePage: React.FC = () => {
+  const navigate = useNavigate()
+  const { t } = useTranslation('project')
+  const { t: tc } = useTranslation('common')
+  const { i18n } = useTranslation()
+  const { user, logout } = useAuth()
+  const { themeMode, darkMode, cycleThemeMode } = useTheme()
+
+  const [activeTab, setActiveTab] = useState(0)
+  const [fabAnchor, setFabAnchor] = useState<null | HTMLElement>(null)
+  const [userMenuAnchor, setUserMenuAnchor] = useState<null | HTMLElement>(null)
+  const [createDialogOpen, setCreateDialogOpen] = useState(false)
+
+  // Projects from store
+  const projects = useProjectStore(s => s.projects)
+  const isLoading = useProjectStore(s => s.isLoading)
+  const error = useProjectStore(s => s.error)
+  const fetchProjects = useProjectStore(s => s.fetchProjects)
+
+  // Standalone playbooks
+  const [playbooks, setPlaybooks] = useState<Playbook[]>([])
+  const [playbooksLoading, setPlaybooksLoading] = useState(false)
+
+  useEffect(() => {
+    fetchProjects()
+    loadPlaybooks()
+  }, [])
+
+  const loadPlaybooks = async () => {
+    setPlaybooksLoading(true)
+    try {
+      const data = await playbookService.listPlaybooks()
+      setPlaybooks(data)
+    } catch {
+      // Handled silently
+    } finally {
+      setPlaybooksLoading(false)
+    }
+  }
+
+  const handleCreatePlaybook = async () => {
+    setFabAnchor(null)
+    try {
+      const newPlaybook = await playbookService.createPlaybook({
+        name: 'Untitled Playbook',
+        description: '',
+        content: {
+          modules: [],
+          links: [],
+          plays: [{
+            id: 'play-1',
+            name: 'Play 1',
+            hosts: 'all',
+            gatherFacts: true,
+            become: false,
+          }],
+          collapsedBlocks: [],
+          collapsedBlockSections: [],
+          metadata: { playbookName: 'Untitled Playbook' },
+          variables: [],
+        },
+      })
+      navigate(`/playbooks/${newPlaybook.id}`)
+    } catch {
+      // Handled silently
+    }
+  }
+
+  const handleLogout = async () => {
+    setUserMenuAnchor(null)
+    await logout()
+    navigate('/login')
+  }
+
+  return (
+    <Box sx={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
+      {/* App Bar */}
+      <AppBar position="static" color="default" elevation={1}>
+        <Toolbar>
+          <Typography variant="h6" sx={{ flex: 1 }}>
+            {tc('appName')}
+          </Typography>
+
+          {user && (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <IconButton onClick={(e) => setUserMenuAnchor(e.currentTarget)}>
+                <Avatar sx={{ width: 32, height: 32, fontSize: '0.875rem', bgcolor: 'primary.main' }}>
+                  {user.username?.charAt(0).toUpperCase()}
+                </Avatar>
+              </IconButton>
+              <Menu
+                anchorEl={userMenuAnchor}
+                open={Boolean(userMenuAnchor)}
+                onClose={() => setUserMenuAnchor(null)}
+              >
+                <MenuItem disabled>
+                  <ListItemText primary={user.username} secondary={user.email} />
+                </MenuItem>
+                <Divider />
+
+                {user.role === 'admin' && (
+                  <MenuItem onClick={() => { setUserMenuAnchor(null); navigate('/admin/accounts') }}>
+                    <ListItemIcon><SupervisorAccountIcon fontSize="small" /></ListItemIcon>
+                    <ListItemText>{tc('accountsManagement')}</ListItemText>
+                  </MenuItem>
+                )}
+
+                <MenuItem onClick={() => { cycleThemeMode() }}>
+                  <ListItemIcon>
+                    {themeMode === 'light' && <Brightness7Icon fontSize="small" />}
+                    {themeMode === 'dark' && <Brightness4Icon fontSize="small" />}
+                    {themeMode === 'system' && <SettingsBrightnessIcon fontSize="small" />}
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={
+                      themeMode === 'light' ? tc('lightMode') :
+                      themeMode === 'dark' ? tc('darkMode') :
+                      tc('systemAuto')
+                    }
+                  />
+                  <Chip
+                    label={themeMode === 'light' ? 'Light' : themeMode === 'dark' ? 'Dark' : 'Auto'}
+                    size="small" variant="outlined"
+                    sx={{ ml: 1, fontSize: '0.7rem', height: 20 }}
+                  />
+                </MenuItem>
+
+                <MenuItem onClick={() => {
+                  const next = i18n.language?.startsWith('fr') ? 'en' : 'fr'
+                  i18n.changeLanguage(next)
+                }}>
+                  <ListItemIcon><LanguageIcon fontSize="small" /></ListItemIcon>
+                  <ListItemText primary={tc('language')} />
+                  <Chip
+                    label={i18n.language?.startsWith('fr') ? 'FR' : 'EN'}
+                    size="small" variant="outlined"
+                    sx={{ ml: 1, fontSize: '0.7rem', height: 20 }}
+                  />
+                </MenuItem>
+
+                <Divider />
+                <MenuItem onClick={handleLogout}>
+                  <ListItemIcon><LogoutIcon fontSize="small" /></ListItemIcon>
+                  <ListItemText>{tc('logout')}</ListItemText>
+                </MenuItem>
+              </Menu>
+            </Box>
+          )}
+        </Toolbar>
+      </AppBar>
+
+      {/* Content */}
+      <Box sx={{ flex: 1, overflow: 'auto', p: 3 }}>
+        <Tabs
+          value={activeTab}
+          onChange={(_e, v) => setActiveTab(v)}
+          sx={{ mb: 3 }}
+        >
+          <Tab label={`${t('projects')} (${projects.length})`} />
+          <Tab label={`${t('standalonePlaybooks')} (${playbooks.length})`} />
+        </Tabs>
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>
+        )}
+
+        {/* Projects Tab */}
+        {activeTab === 0 && (
+          <Box>
+            {isLoading ? (
+              <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+                <CircularProgress />
+              </Box>
+            ) : projects.length === 0 ? (
+              <Typography color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
+                {t('noProjects')}
+              </Typography>
+            ) : (
+              <Box sx={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))',
+                gap: 2,
+              }}>
+                {projects.map(project => (
+                  <ProjectCard key={project.id} project={project} />
+                ))}
+              </Box>
+            )}
+          </Box>
+        )}
+
+        {/* Standalone Playbooks Tab */}
+        {activeTab === 1 && (
+          <Box>
+            {playbooksLoading ? (
+              <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+                <CircularProgress />
+              </Box>
+            ) : playbooks.length === 0 ? (
+              <Typography color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
+                {t('noPlaybooks')}
+              </Typography>
+            ) : (
+              <List>
+                {playbooks.map(playbook => (
+                  <ListItem key={playbook.id} disablePadding>
+                    <ListItemButton onClick={() => navigate(`/playbooks/${playbook.id}`)}>
+                      <ListItemIcon><DescriptionIcon /></ListItemIcon>
+                      <ListItemText
+                        primary={playbook.name}
+                        secondary={playbook.description || undefined}
+                      />
+                      {playbook.is_shared && (
+                        <Chip
+                          label={playbook.user_role}
+                          size="small"
+                          variant="outlined"
+                          color="info"
+                        />
+                      )}
+                    </ListItemButton>
+                  </ListItem>
+                ))}
+              </List>
+            )}
+          </Box>
+        )}
+      </Box>
+
+      {/* FAB with dropdown */}
+      <Fab
+        color="primary"
+        sx={{ position: 'fixed', bottom: 24, right: 24 }}
+        onClick={(e) => setFabAnchor(e.currentTarget)}
+      >
+        <AddIcon />
+      </Fab>
+      <Menu
+        anchorEl={fabAnchor}
+        open={Boolean(fabAnchor)}
+        onClose={() => setFabAnchor(null)}
+        anchorOrigin={{ vertical: 'top', horizontal: 'left' }}
+        transformOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      >
+        <MenuItem onClick={() => { setFabAnchor(null); setCreateDialogOpen(true) }}>
+          <ListItemIcon><FolderIcon /></ListItemIcon>
+          <ListItemText>{t('newProject')}</ListItemText>
+        </MenuItem>
+        <MenuItem onClick={handleCreatePlaybook}>
+          <ListItemIcon><DescriptionIcon /></ListItemIcon>
+          <ListItemText>{t('newPlaybook')}</ListItemText>
+        </MenuItem>
+      </Menu>
+
+      <CreateProjectDialog
+        open={createDialogOpen}
+        onClose={() => setCreateDialogOpen(false)}
+      />
+    </Box>
+  )
+}
+
+export default HomePage

--- a/frontend/src/services/projectService.ts
+++ b/frontend/src/services/projectService.ts
@@ -1,0 +1,128 @@
+import { getHttpClient } from '../utils/httpClient'
+
+export interface Project {
+  id: string
+  name: string
+  description: string | null
+  owner_id: string
+  git_url: string | null
+  git_branch: string | null
+  git_credentials_id: string | null
+  settings: Record<string, any> | null
+  created_at: string
+  updated_at: string
+  owner_username: string | null
+  user_role: string | null
+  is_shared: boolean
+}
+
+export interface ProjectArtifact {
+  id: string
+  project_id: string
+  artifact_type: string
+  path: string
+  content: any
+  raw_content: string | null
+  version: number
+  metadata: Record<string, any> | null
+  created_at: string
+  updated_at: string
+}
+
+export interface ProjectCreate {
+  name: string
+  description?: string
+}
+
+export interface ProjectUpdate {
+  name?: string
+  description?: string
+  git_url?: string | null
+  git_branch?: string | null
+  settings?: Record<string, any> | null
+}
+
+export const projectService = {
+  async listProjects(): Promise<Project[]> {
+    try {
+      const client = getHttpClient()
+      const response = await client.get('/projects')
+      return response.data
+    } catch (error: any) {
+      console.error('List projects API error:', error)
+      if (error.response?.data?.detail) {
+        throw new Error(error.response.data.detail)
+      }
+      throw new Error('Failed to list projects')
+    }
+  },
+
+  async createProject(data: ProjectCreate): Promise<Project> {
+    try {
+      const client = getHttpClient()
+      const response = await client.post('/projects', data)
+      return response.data
+    } catch (error: any) {
+      console.error('Create project API error:', error)
+      if (error.response?.data?.detail) {
+        throw new Error(error.response.data.detail)
+      }
+      throw new Error('Failed to create project')
+    }
+  },
+
+  async getProject(id: string): Promise<Project> {
+    try {
+      const client = getHttpClient()
+      const response = await client.get(`/projects/${id}`)
+      return response.data
+    } catch (error: any) {
+      console.error('Get project API error:', error)
+      if (error.response?.data?.detail) {
+        throw new Error(error.response.data.detail)
+      }
+      throw new Error('Failed to get project')
+    }
+  },
+
+  async updateProject(id: string, data: ProjectUpdate): Promise<Project> {
+    try {
+      const client = getHttpClient()
+      const response = await client.put(`/projects/${id}`, data)
+      return response.data
+    } catch (error: any) {
+      console.error('Update project API error:', error)
+      if (error.response?.data?.detail) {
+        throw new Error(error.response.data.detail)
+      }
+      throw new Error('Failed to update project')
+    }
+  },
+
+  async deleteProject(id: string): Promise<void> {
+    try {
+      const client = getHttpClient()
+      await client.delete(`/projects/${id}`)
+    } catch (error: any) {
+      console.error('Delete project API error:', error)
+      if (error.response?.data?.detail) {
+        throw new Error(error.response.data.detail)
+      }
+      throw new Error('Failed to delete project')
+    }
+  },
+
+  async listArtifacts(projectId: string): Promise<ProjectArtifact[]> {
+    try {
+      const client = getHttpClient()
+      const response = await client.get(`/projects/${projectId}/artifacts`)
+      return response.data
+    } catch (error: any) {
+      console.error('List artifacts API error:', error)
+      if (error.response?.data?.detail) {
+        throw new Error(error.response.data.detail)
+      }
+      throw new Error('Failed to list artifacts')
+    }
+  },
+}

--- a/frontend/src/stores/editorStore.ts
+++ b/frontend/src/stores/editorStore.ts
@@ -1,0 +1,56 @@
+import { create } from 'zustand'
+
+export interface EditorTab {
+  id: string
+  title: string
+  type: 'playbook' | 'role' | 'inventory' | 'variable_file' | 'template' | 'file'
+  artifactId: string
+  artifactPath: string
+}
+
+interface EditorState {
+  tabs: EditorTab[]
+  activeTabIndex: number
+
+  openTab: (tab: Omit<EditorTab, 'id'>) => void
+  closeTab: (tabId: string) => void
+  setActiveTab: (index: number) => void
+  closeAllTabs: () => void
+}
+
+export const useEditorStore = create<EditorState>((set, get) => ({
+  tabs: [],
+  activeTabIndex: 0,
+
+  openTab: (tab) => {
+    const { tabs } = get()
+    const existingIndex = tabs.findIndex(t => t.artifactId === tab.artifactId)
+    if (existingIndex >= 0) {
+      set({ activeTabIndex: existingIndex })
+      return
+    }
+    const newTab: EditorTab = { ...tab, id: `tab-${Date.now()}` }
+    set(state => ({
+      tabs: [...state.tabs, newTab],
+      activeTabIndex: state.tabs.length,
+    }))
+  },
+
+  closeTab: (tabId) => {
+    set(state => {
+      const newTabs = state.tabs.filter(t => t.id !== tabId)
+      const closedIndex = state.tabs.findIndex(t => t.id === tabId)
+      let newActiveIndex = state.activeTabIndex
+      if (closedIndex <= state.activeTabIndex && state.activeTabIndex > 0) {
+        newActiveIndex = state.activeTabIndex - 1
+      }
+      if (newActiveIndex >= newTabs.length) {
+        newActiveIndex = Math.max(0, newTabs.length - 1)
+      }
+      return { tabs: newTabs, activeTabIndex: newActiveIndex }
+    })
+  },
+
+  setActiveTab: (index) => set({ activeTabIndex: index }),
+  closeAllTabs: () => set({ tabs: [], activeTabIndex: 0 }),
+}))

--- a/frontend/src/stores/projectStore.ts
+++ b/frontend/src/stores/projectStore.ts
@@ -1,0 +1,87 @@
+import { create } from 'zustand'
+import { projectService, Project, ProjectArtifact, ProjectCreate } from '../services/projectService'
+
+interface ProjectState {
+  projects: Project[]
+  currentProject: Project | null
+  artifacts: ProjectArtifact[]
+  isLoading: boolean
+  error: string | null
+
+  fetchProjects: () => Promise<void>
+  fetchProject: (id: string) => Promise<void>
+  fetchArtifacts: (projectId: string) => Promise<void>
+  createProject: (data: ProjectCreate) => Promise<Project>
+  deleteProject: (id: string) => Promise<void>
+  clearCurrentProject: () => void
+  clearError: () => void
+}
+
+export const useProjectStore = create<ProjectState>((set) => ({
+  projects: [],
+  currentProject: null,
+  artifacts: [],
+  isLoading: false,
+  error: null,
+
+  fetchProjects: async () => {
+    set({ isLoading: true, error: null })
+    try {
+      const projects = await projectService.listProjects()
+      set({ projects, isLoading: false })
+    } catch (error: any) {
+      set({ error: error.message, isLoading: false })
+    }
+  },
+
+  fetchProject: async (id: string) => {
+    set({ isLoading: true, error: null })
+    try {
+      const project = await projectService.getProject(id)
+      set({ currentProject: project, isLoading: false })
+    } catch (error: any) {
+      set({ error: error.message, isLoading: false })
+    }
+  },
+
+  fetchArtifacts: async (projectId: string) => {
+    try {
+      const artifacts = await projectService.listArtifacts(projectId)
+      set({ artifacts })
+    } catch (error: any) {
+      set({ error: error.message })
+    }
+  },
+
+  createProject: async (data: ProjectCreate) => {
+    set({ isLoading: true, error: null })
+    try {
+      const project = await projectService.createProject(data)
+      set(state => ({
+        projects: [...state.projects, project],
+        isLoading: false,
+      }))
+      return project
+    } catch (error: any) {
+      set({ error: error.message, isLoading: false })
+      throw error
+    }
+  },
+
+  deleteProject: async (id: string) => {
+    set({ isLoading: true, error: null })
+    try {
+      await projectService.deleteProject(id)
+      set(state => ({
+        projects: state.projects.filter(p => p.id !== id),
+        isLoading: false,
+      }))
+    } catch (error: any) {
+      set({ error: error.message, isLoading: false })
+      throw error
+    }
+  },
+
+  clearCurrentProject: () => set({ currentProject: null, artifacts: [] }),
+  clearError: () => set({ error: null }),
+}))


### PR DESCRIPTION
## Summary

- Adds a **HomePage** (`/`) with Projects and Standalone Playbooks tabs, replacing direct MainLayout landing
- Adds **ProjectLayout** (`/projects/:projectId`) — a project workbench with artifact tree, modules panel, and system zone
- Adds **project API service** (`projectService.ts`) and **Zustand stores** (`projectStore`, `editorStore`)
- Adds **i18n project namespace** (EN/FR) with all project-related translations
- Updates **routing**: `/` → HomePage, `/projects/:id` → ProjectLayout, `/playbooks/:id` → MainLayout
- **MainLayout** now reads `playbookId` from route params and auto-loads the playbook on mount
- **AppHeader** gets a home navigation button

**Depends on #6** (refactor/extract-visual-canvas — base branch)
**Depends on #8** (feat/project-data-model — backend Project API)

### New files (11)

| File | Purpose |
|------|---------|
| `projectService.ts` | Project + artifact API client |
| `projectStore.ts` | Zustand store: project list, current project, artifacts |
| `editorStore.ts` | Zustand store: open tabs + active tab |
| `en/project.json` / `fr/project.json` | i18n translations |
| `HomePage.tsx` | Home page with tabs + FAB create menu |
| `ProjectCard.tsx` | Card component for project list |
| `CreateProjectDialog.tsx` | Create project dialog |
| `ProjectTree.tsx` | Artifact tree grouped by type |
| `ProjectHeader.tsx` | Compact project header with breadcrumb |
| `ProjectLayout.tsx` | Project workbench 4-zone layout |

### Modified files (4)

| File | Change |
|------|--------|
| `App.tsx` | New routes |
| `MainLayout.tsx` | Read playbookId from useParams, auto-load |
| `AppHeader.tsx` | Home navigation button |
| `i18n/index.ts` | Register project namespace |

## Test plan

- [ ] Login → lands on HomePage (not editor)
- [ ] "Standalone Playbooks" tab shows existing playbooks
- [ ] Click playbook → navigates to `/playbooks/:id` → MainLayout editor works
- [ ] Create new project → navigates to `/projects/:id` → ProjectLayout shows
- [ ] Project tree shows (empty for new project)
- [ ] Back-to-home button works from both project and playbook views
- [ ] Language toggle works for all new strings
- [ ] All 181 existing tests pass
- [ ] TypeScript compiles cleanly, production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)