### PR TITLE
feat: event sourcing — persist playbook events via WebSocket

### DIFF
--- a/backend/app/api/endpoints/playbooks.py
+++ b/backend/app/api/endpoints/playbooks.py
@@ -40,6 +40,7 @@ from app.services.playbook_access_service import (
     check_playbook_access,
     log_playbook_action
 )
+from app.services import playbook_event_service
 
 router = APIRouter(prefix="/playbooks", tags=["playbooks"])
 
@@ -181,7 +182,16 @@ async def get_playbook(
         HTTPException 403: Not authorized to access this playbook
     """
     playbook, role = await check_playbook_access(playbook_id, current_user.id, db)
-    return playbook
+
+    # Fetch events since the last snapshot
+    events = await playbook_event_service.get_events_since(
+        playbook_id, playbook.snapshot_sequence, db
+    )
+
+    # Build response with events_delta
+    response = PlaybookDetailResponse.model_validate(playbook)
+    response.events_delta = events
+    return response
 
 
 @router.put("/{playbook_id}", response_model=PlaybookDetailResponse)

--- a/backend/app/api/endpoints/websocket.py
+++ b/backend/app/api/endpoints/websocket.py
@@ -12,13 +12,66 @@ from typing import Optional
 
 from app.core.database import get_db, AsyncSessionLocal
 from app.core.security import decode_access_token
+from app.core.dependencies import get_current_user
 from app.models import Playbook, PlaybookShare, PlaybookRole
+from app.models.user import User
+from app.models.project_collaboration import ProjectRole
 from app.services.websocket_manager import websocket_manager
 from app.services.playbook_access_service import check_playbook_access_standalone
+from app.services.project_access_service import check_project_access_standalone
+from app.services import playbook_event_service
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Event-sourcing: snapshot callback
+# ---------------------------------------------------------------------------
+
+async def _take_snapshot(project_id: str, artifact_id: str):
+    """
+    Create a snapshot for a playbook (artifact_id) by folding pending events
+    into the stored content.  Called by WebSocketManager on inactivity,
+    threshold, or last-user-disconnect triggers.
+    """
+    try:
+        async with AsyncSessionLocal() as db:
+            from sqlalchemy import select as sa_select
+            from app.models.playbook import Playbook as PB
+
+            result = await db.execute(sa_select(PB).where(PB.id == artifact_id))
+            playbook = result.scalar_one_or_none()
+            if not playbook:
+                logger.warning("Snapshot skipped — playbook %s not found", artifact_id)
+                return
+
+            events = await playbook_event_service.get_events_since(
+                artifact_id, playbook.snapshot_sequence, db
+            )
+            if not events:
+                return
+
+            # The latest event's data already contains the full content
+            # (the frontend sends the complete state on each update).
+            # We take the data from the most recent event as the snapshot.
+            latest = events[-1]
+            content = latest.data if latest.data else playbook.content
+            await playbook_event_service.create_snapshot(
+                artifact_id, content, latest.sequence_number, db
+            )
+            await db.commit()
+            websocket_manager.reset_event_counter(project_id, artifact_id)
+            logger.info(
+                "Snapshot created for playbook %s at seq %d (%d events folded)",
+                artifact_id, latest.sequence_number, len(events),
+            )
+    except Exception as e:
+        logger.error("Snapshot failed for playbook %s: %s", artifact_id, e)
+
+
+websocket_manager.register_snapshot_callback(_take_snapshot)
 
 
 async def get_current_user_ws(
@@ -51,19 +104,23 @@ async def get_current_user_ws(
         return None
 
 
-@router.websocket("/ws/playbook/{playbook_id}")
-async def playbook_websocket(
+# ---------------------------------------------------------------------------
+# Project-centric WebSocket endpoint (new)
+# ---------------------------------------------------------------------------
+
+@router.websocket("/ws/project/{project_id}")
+async def project_websocket(
     websocket: WebSocket,
-    playbook_id: str,
+    project_id: str,
     token: Optional[str] = Query(None)
 ):
     """
-    WebSocket endpoint for real-time playbook collaboration
+    WebSocket endpoint for real-time project collaboration
 
-    Connect: ws://host/ws/playbook/{playbook_id}?token={jwt_token}
+    Connect: ws://host/ws/project/{project_id}?token={jwt_token}
 
     Messages from client:
-    - {"type": "update", "data": {...}} - Playbook update
+    - {"type": "update", "data": {...}, "artifact_id": "..."} - Project update
     - {"type": "cursor", "position": {...}} - Cursor position (future)
     - {"type": "ping"} - Keep-alive ping
 
@@ -71,11 +128,213 @@ async def playbook_websocket(
     - {"type": "presence", "users": [...]} - Current users in room
     - {"type": "user_joined", "user_id": "...", "username": "..."} - User joined
     - {"type": "user_left", "user_id": "...", "username": "..."} - User left
-    - {"type": "update", "user_id": "...", "data": {...}} - Update from another user
+    - {"type": "update", "user_id": "...", "data": {...}, "artifact_id": "..."} - Update from another user
     - {"type": "pong"} - Response to ping
     - {"type": "error", "message": "..."} - Error message
     """
-    logger.info(f"[WS] Connection attempt - playbook={playbook_id}, token={'exists' if token else 'MISSING'}")
+    logger.info(f"[WS] Connection attempt - project={project_id}, token={'exists' if token else 'MISSING'}")
+
+    # Authenticate user
+    user = await get_current_user_ws(websocket, token)
+    if not user:
+        logger.warning(f"[WS] Auth failed for project={project_id}")
+        await websocket.close(code=4001, reason="Authentication required")
+        return
+
+    user_id = user["user_id"]
+    username = user["username"]
+    logger.info(f"[WS] User authenticated: {username} ({user_id})")
+
+    try:
+        # Check project access before connecting
+        user_role = await check_project_access_standalone(project_id, user_id)
+        logger.info(f"[WS] Access check - project={project_id}, user={user_id}, role={user_role}")
+        if not user_role:
+            logger.warning(f"[WS] Access denied for user={user_id} to project={project_id}")
+            await websocket.close(code=4003, reason="Access denied to this project")
+            return
+
+        # Connect to room
+        await websocket_manager.connect(websocket, project_id, user_id, username)
+
+        # Send initial role info to client
+        await websocket_manager.send_personal(
+            websocket,
+            {"type": "connected", "role": user_role, "project_id": project_id}
+        )
+
+        # Main message loop
+        while True:
+            try:
+                data = await websocket.receive_json()
+                await handle_project_message(websocket, project_id, user_id, username, user_role, data)
+            except json.JSONDecodeError:
+                await websocket_manager.send_personal(
+                    websocket,
+                    {"type": "error", "message": "Invalid JSON"}
+                )
+
+    except WebSocketDisconnect:
+        logger.info(f"WebSocket disconnected: user={user_id}, project={project_id}")
+    except Exception as e:
+        logger.error(f"WebSocket error: {e}")
+    finally:
+        await websocket_manager.disconnect(project_id, user_id)
+
+
+async def handle_project_message(
+    websocket: WebSocket,
+    project_id: str,
+    user_id: str,
+    username: str,
+    user_role: str,
+    data: dict
+):
+    """
+    Handle incoming WebSocket message for project rooms
+
+    Args:
+        websocket: The WebSocket connection
+        project_id: The project ID
+        user_id: The user's ID
+        username: The user's username
+        user_role: The user's role (owner, editor, viewer)
+        data: The message data
+    """
+    msg_type = data.get("type")
+
+    if msg_type == "ping":
+        await websocket_manager.send_personal(
+            websocket,
+            {"type": "pong", "timestamp": data.get("timestamp")}
+        )
+
+    elif msg_type == "update":
+        # Only owners and editors can send updates
+        if user_role == ProjectRole.VIEWER.value:
+            await websocket_manager.send_personal(
+                websocket,
+                {"type": "error", "message": "Viewers cannot send updates"}
+            )
+            return
+
+        update_data = data.get("data", {})
+        update_type = data.get("update_type", "content")
+        artifact_id = data.get("artifact_id")
+        event_type = data.get("event_type", update_type)
+
+        # --- Event sourcing: persist event BEFORE broadcasting ---
+        sequence_number = None
+        if artifact_id:
+            try:
+                async with AsyncSessionLocal() as db:
+                    event = await playbook_event_service.save_event(
+                        playbook_id=artifact_id,
+                        user_id=user_id,
+                        event_type=event_type,
+                        data=update_data,
+                        db=db,
+                    )
+                    await db.commit()
+                    sequence_number = event.sequence_number
+                # Track for snapshot triggers
+                websocket_manager.record_event(project_id, artifact_id)
+            except Exception as e:
+                logger.error("Failed to persist event: %s", e)
+                await websocket_manager.send_personal(
+                    websocket,
+                    {"type": "error", "message": "Failed to persist event"}
+                )
+                return
+
+        # ACK to sender
+        ack = {"type": "event_ack"}
+        if sequence_number is not None:
+            ack["sequence_number"] = sequence_number
+        await websocket_manager.send_personal(websocket, ack)
+
+        # Broadcast update to other users
+        await websocket_manager.broadcast_update(
+            project_id=project_id,
+            user_id=user_id,
+            username=username,
+            update_type=update_type,
+            data=update_data,
+            artifact_id=artifact_id
+        )
+
+    elif msg_type == "set_artifact":
+        # Any role can set their current artifact
+        artifact_id = data.get("artifact_id") or None
+        websocket_manager.set_user_artifact(project_id, user_id, artifact_id)
+
+        # Broadcast updated presence to all room members
+        users = websocket_manager.get_room_users(project_id)
+        await websocket_manager.broadcast_to_room(
+            project_id,
+            {
+                "type": "presence",
+                "users": users,
+                "project_id": project_id
+            }
+        )
+
+    elif msg_type == "get_presence":
+        # Request current presence
+        users = websocket_manager.get_room_users(project_id)
+        await websocket_manager.send_personal(
+            websocket,
+            {
+                "type": "presence",
+                "users": users,
+                "project_id": project_id
+            }
+        )
+
+    else:
+        await websocket_manager.send_personal(
+            websocket,
+            {"type": "error", "message": f"Unknown message type: {msg_type}"}
+        )
+
+
+@router.get("/ws/project/{project_id}/presence")
+async def get_project_presence(
+    project_id: str,
+    current_user: User = Depends(get_current_user)
+):
+    """
+    Get current users connected to a project (REST endpoint)
+
+    This is useful for getting presence without WebSocket connection.
+    Requires authentication.
+    """
+    users = websocket_manager.get_room_users(project_id)
+    return {
+        "project_id": project_id,
+        "users": users,
+        "count": len(users)
+    }
+
+
+# ---------------------------------------------------------------------------
+# Legacy playbook-centric WebSocket endpoint (deprecated — remove after
+# frontend migration is complete)
+# ---------------------------------------------------------------------------
+
+@router.websocket("/ws/playbook/{playbook_id}")
+async def playbook_websocket(
+    websocket: WebSocket,
+    playbook_id: str,
+    token: Optional[str] = Query(None)
+):
+    """
+    [DEPRECATED] WebSocket endpoint for real-time playbook collaboration.
+    Use /ws/project/{project_id} instead.
+
+    Kept temporarily for legacy MainLayout route compatibility.
+    """
+    logger.info(f"[WS] Connection attempt (legacy) - playbook={playbook_id}, token={'exists' if token else 'MISSING'}")
 
     # Authenticate user
     user = await get_current_user_ws(websocket, token)
@@ -134,15 +393,7 @@ async def handle_message(
     data: dict
 ):
     """
-    Handle incoming WebSocket message
-
-    Args:
-        websocket: The WebSocket connection
-        playbook_id: The playbook ID
-        user_id: The user's ID
-        username: The user's username
-        user_role: The user's role (owner, editor, viewer)
-        data: The message data
+    Handle incoming WebSocket message (legacy playbook handler)
     """
     msg_type = data.get("type")
 
@@ -166,7 +417,7 @@ async def handle_message(
         update_type = data.get("update_type", "content")
 
         await websocket_manager.broadcast_update(
-            playbook_id=playbook_id,
+            project_id=playbook_id,
             user_id=user_id,
             username=username,
             update_type=update_type,
@@ -195,9 +446,8 @@ async def handle_message(
 @router.get("/ws/playbook/{playbook_id}/presence")
 async def get_playbook_presence(playbook_id: str):
     """
-    Get current users connected to a playbook (REST endpoint)
-
-    This is useful for getting presence without WebSocket connection.
+    [DEPRECATED] Get current users connected to a playbook (REST endpoint).
+    Use /ws/project/{project_id}/presence instead.
     """
     users = websocket_manager.get_room_users(playbook_id)
     return {

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
-from sqlalchemy import select
+from sqlalchemy import select, text, inspect as sa_inspect
 from app.core.config import settings
 from app.core.database import init_db, AsyncSessionLocal
 from app.core.security import get_password_hash
@@ -59,6 +59,22 @@ async def lifespan(app: FastAPI):
     try:
         await init_db()
         print("Database initialized successfully")
+
+        # Ensure snapshot_sequence column exists on playbooks table
+        # (create_all won't add columns to existing tables)
+        from app.core.database import engine as _engine
+        async with _engine.begin() as conn:
+            def _check_and_add_column(sync_conn):
+                inspector = sa_inspect(sync_conn)
+                columns = [c["name"] for c in inspector.get_columns("playbooks")]
+                if "snapshot_sequence" not in columns:
+                    sync_conn.execute(
+                        text("ALTER TABLE playbooks ADD COLUMN snapshot_sequence INTEGER DEFAULT 0 NOT NULL")
+                    )
+                    print("Added snapshot_sequence column to playbooks table")
+                else:
+                    print("snapshot_sequence column already exists")
+            await conn.run_sync(_check_and_add_column)
         
         # Create default admin user for testing
         await create_default_user()

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -8,6 +8,7 @@ from .project import Project
 from .project_artifact import ProjectArtifact, ArtifactType
 from .project_collaboration import ProjectShare, ProjectRole
 from .git_credential import GitCredential, GitProvider
+from .playbook_event import PlaybookEvent
 
 __all__ = [
     "User",
@@ -26,4 +27,5 @@ __all__ = [
     "ProjectRole",
     "GitCredential",
     "GitProvider",
+    "PlaybookEvent",
 ]

--- a/backend/app/models/playbook.py
+++ b/backend/app/models/playbook.py
@@ -48,6 +48,9 @@ class Playbook(Base):
     # Version for optimistic locking (incremented on each update)
     version = Column(Integer, default=1, nullable=False)
 
+    # Last event sequence_number folded into the content/snapshot
+    snapshot_sequence = Column(Integer, default=0, nullable=False)
+
     # Project association (nullable — standalone playbooks have no project)
     project_id = Column(String, ForeignKey("projects.id", ondelete="SET NULL"), nullable=True, index=True)
 

--- a/backend/app/models/playbook_event.py
+++ b/backend/app/models/playbook_event.py
@@ -1,0 +1,72 @@
+"""
+PlaybookEvent model for event-sourcing playbook mutations.
+
+Each user action (add module, delete link, update play, etc.) is recorded
+as an immutable event with a per-playbook sequence number.
+"""
+
+from sqlalchemy import Column, String, DateTime, ForeignKey, JSON, BigInteger, Index
+from datetime import datetime
+import uuid
+from app.core.database import Base
+
+
+def generate_uuid():
+    """Generate UUID as string"""
+    return str(uuid.uuid4())
+
+
+class PlaybookEvent(Base):
+    """
+    Immutable event representing a single mutation on a playbook.
+
+    Attributes:
+        id: Unique event identifier (UUID)
+        playbook_id: Target playbook
+        user_id: User who triggered the event
+        event_type: Short action label (module_add, link_delete, play_update, ...)
+        data: Arbitrary JSON payload describing the mutation
+        sequence_number: Monotonically increasing per playbook
+        created_at: Timestamp of the event
+    """
+
+    __tablename__ = "playbook_events"
+
+    id = Column(String, primary_key=True, default=generate_uuid)
+    playbook_id = Column(
+        String,
+        ForeignKey("playbooks.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    user_id = Column(
+        String,
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    event_type = Column(String(50), nullable=False)
+    data = Column(JSON, nullable=True)
+    sequence_number = Column(BigInteger, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        Index("ix_playbook_events_pb_seq", "playbook_id", "sequence_number", unique=True),
+    )
+
+    def __repr__(self):
+        return (
+            f"<PlaybookEvent #{self.sequence_number} "
+            f"type={self.event_type} playbook={self.playbook_id}>"
+        )
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "playbook_id": self.playbook_id,
+            "user_id": self.user_id,
+            "event_type": self.event_type,
+            "data": self.data,
+            "sequence_number": self.sequence_number,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+        }

--- a/backend/app/schemas/playbook.py
+++ b/backend/app/schemas/playbook.py
@@ -3,7 +3,7 @@ Playbook schemas for request/response validation
 """
 
 from pydantic import BaseModel, Field
-from typing import Optional, Any
+from typing import Optional, Any, List
 from datetime import datetime
 
 
@@ -46,10 +46,26 @@ class PlaybookResponse(PlaybookBase):
         from_attributes = True
 
 
+class PlaybookEventResponse(BaseModel):
+    """Schema for a single playbook event in the delta."""
+    id: str
+    playbook_id: str
+    user_id: Optional[str] = None
+    event_type: str
+    data: Optional[dict] = None
+    sequence_number: int
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
 class PlaybookDetailResponse(PlaybookResponse):
     """Schema for detailed playbook response (includes content)"""
     content: dict
     version: int = 1
+    snapshot_sequence: int = 0
+    events_delta: List[PlaybookEventResponse] = Field(default_factory=list)
 
 
 class PlaybookYamlResponse(BaseModel):

--- a/backend/app/services/playbook_event_service.py
+++ b/backend/app/services/playbook_event_service.py
@@ -1,0 +1,105 @@
+"""
+Playbook Event-Sourcing Service
+
+Provides helpers to persist playbook mutation events with
+auto-incremented per-playbook sequence numbers, query event
+deltas, and fold events back into a snapshot.
+"""
+
+from typing import List, Optional
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select, func
+import logging
+
+from app.models.playbook_event import PlaybookEvent
+from app.models.playbook import Playbook
+
+logger = logging.getLogger(__name__)
+
+
+async def get_next_sequence(playbook_id: str, db: AsyncSession) -> int:
+    """
+    Return the next sequence_number for *playbook_id*.
+
+    This is ``MAX(sequence_number) + 1`` among existing events,
+    or ``1`` if no events exist yet.
+    """
+    result = await db.execute(
+        select(func.max(PlaybookEvent.sequence_number))
+        .where(PlaybookEvent.playbook_id == playbook_id)
+    )
+    current_max = result.scalar()
+    return (current_max or 0) + 1
+
+
+async def save_event(
+    playbook_id: str,
+    user_id: Optional[str],
+    event_type: str,
+    data: dict,
+    db: AsyncSession,
+) -> PlaybookEvent:
+    """
+    Persist a new PlaybookEvent with an auto-incremented sequence number.
+
+    Returns the flushed (but not yet committed) event so the caller
+    can bundle it inside a larger transaction.
+    """
+    seq = await get_next_sequence(playbook_id, db)
+    event = PlaybookEvent(
+        playbook_id=playbook_id,
+        user_id=user_id,
+        event_type=event_type,
+        data=data,
+        sequence_number=seq,
+    )
+    db.add(event)
+    await db.flush()
+    logger.debug(
+        "Saved event #%d type=%s for playbook %s",
+        seq, event_type, playbook_id,
+    )
+    return event
+
+
+async def get_events_since(
+    playbook_id: str,
+    since_sequence: int,
+    db: AsyncSession,
+) -> List[PlaybookEvent]:
+    """
+    Return all events for *playbook_id* whose ``sequence_number``
+    is strictly greater than *since_sequence*, ordered ascending.
+    """
+    result = await db.execute(
+        select(PlaybookEvent)
+        .where(PlaybookEvent.playbook_id == playbook_id)
+        .where(PlaybookEvent.sequence_number > since_sequence)
+        .order_by(PlaybookEvent.sequence_number)
+    )
+    return list(result.scalars().all())
+
+
+async def create_snapshot(
+    playbook_id: str,
+    content: dict,
+    sequence_number: int,
+    db: AsyncSession,
+) -> Playbook:
+    """
+    Update the playbook's ``content`` (the full snapshot) and set
+    ``snapshot_sequence`` to *sequence_number* so future delta
+    queries skip already-folded events.
+    """
+    result = await db.execute(
+        select(Playbook).where(Playbook.id == playbook_id)
+    )
+    playbook = result.scalar_one()
+    playbook.content = content
+    playbook.snapshot_sequence = sequence_number
+    await db.flush()
+    logger.info(
+        "Snapshot updated for playbook %s at sequence %d",
+        playbook_id, sequence_number,
+    )
+    return playbook

--- a/backend/app/services/websocket_manager.py
+++ b/backend/app/services/websocket_manager.py
@@ -1,15 +1,15 @@
 """
 WebSocket Connection Manager for real-time collaboration
 
-Manages WebSocket connections per playbook and broadcasts updates
+Manages WebSocket connections per project and broadcasts updates
 to all connected users.
 """
 
 from fastapi import WebSocket
-from typing import Dict, List, Set, Optional
+from typing import Dict, List, Set, Optional, Callable, Awaitable
 from dataclasses import dataclass, field
 from datetime import datetime
-import json
+import asyncio
 import logging
 
 logger = logging.getLogger(__name__)
@@ -22,13 +22,18 @@ class ConnectedUser:
     username: str
     websocket: WebSocket
     connected_at: datetime = field(default_factory=datetime.utcnow)
+    current_artifact_id: Optional[str] = None
 
 
 @dataclass
-class PlaybookRoom:
-    """Represents a room for a playbook with connected users"""
-    playbook_id: str
+class ProjectRoom:
+    """Represents a room for a project with connected users"""
+    project_id: str
     connections: Dict[str, ConnectedUser] = field(default_factory=dict)
+    # Event-sourcing: tracks per-artifact event counts since last snapshot
+    events_since_snapshot: Dict[str, int] = field(default_factory=dict)
+    # Inactivity timers per artifact_id
+    _inactivity_timers: Dict[str, "asyncio.TimerHandle"] = field(default_factory=dict)
 
     def add_user(self, user_id: str, username: str, websocket: WebSocket):
         """Add a user to the room"""
@@ -49,7 +54,8 @@ class PlaybookRoom:
             {
                 "user_id": conn.user_id,
                 "username": conn.username,
-                "connected_at": conn.connected_at.isoformat()
+                "connected_at": conn.connected_at.isoformat(),
+                "current_artifact_id": conn.current_artifact_id
             }
             for conn in self.connections.values()
         ]
@@ -58,64 +64,87 @@ class PlaybookRoom:
         """Check if room is empty"""
         return len(self.connections) == 0
 
+    def users_on_artifact(self, artifact_id: str) -> int:
+        """Count how many users have *artifact_id* as their current artifact."""
+        return sum(
+            1 for c in self.connections.values()
+            if c.current_artifact_id == artifact_id
+        )
+
 
 class WebSocketManager:
     """
     Manages WebSocket connections for real-time collaboration
 
     Features:
-    - Room-based connections (one room per playbook)
+    - Room-based connections (one room per project)
     - Broadcast updates to all users in a room
     - Presence tracking (who is connected)
     - Message routing
     """
 
+    # Snapshot triggers
+    INACTIVITY_SECONDS = 60
+    EVENT_THRESHOLD = 500
+
     def __init__(self):
-        # playbook_id -> PlaybookRoom
-        self.rooms: Dict[str, PlaybookRoom] = {}
-        # user_id -> set of playbook_ids (user can be in multiple rooms)
+        # project_id -> ProjectRoom
+        self.rooms: Dict[str, ProjectRoom] = {}
+        # user_id -> set of project_ids (user can be in multiple rooms)
         self.user_rooms: Dict[str, Set[str]] = {}
+        # Optional callback: async fn(project_id, artifact_id) called when a
+        # snapshot should be taken.  Set by the WS endpoint module at startup.
+        self._snapshot_callback: Optional[
+            Callable[[str, str], Awaitable[None]]
+        ] = None
+
+    def register_snapshot_callback(
+        self, callback: Callable[[str, str], Awaitable[None]]
+    ):
+        """Register async callback(project_id, artifact_id) for snapshot triggers."""
+        self._snapshot_callback = callback
 
     async def connect(
         self,
         websocket: WebSocket,
-        playbook_id: str,
+        project_id: str,
         user_id: str,
         username: str
     ):
         """
-        Connect a user to a playbook room
+        Connect a user to a project room
 
         Args:
             websocket: The WebSocket connection
-            playbook_id: The playbook to join
+            project_id: The project to join
             user_id: The user's ID
             username: The user's username (for display)
         """
         await websocket.accept()
 
         # Create room if doesn't exist
-        if playbook_id not in self.rooms:
-            self.rooms[playbook_id] = PlaybookRoom(playbook_id=playbook_id)
+        if project_id not in self.rooms:
+            self.rooms[project_id] = ProjectRoom(project_id=project_id)
 
         # Add user to room
-        room = self.rooms[playbook_id]
+        room = self.rooms[project_id]
         room.add_user(user_id, username, websocket)
 
         # Track user's rooms
         if user_id not in self.user_rooms:
             self.user_rooms[user_id] = set()
-        self.user_rooms[user_id].add(playbook_id)
+        self.user_rooms[user_id].add(project_id)
 
-        logger.info(f"User {username} ({user_id}) connected to playbook {playbook_id}")
+        logger.info(f"User {username} ({user_id}) connected to project {project_id}")
 
         # Notify others that user joined
         await self.broadcast_to_room(
-            playbook_id,
+            project_id,
             {
                 "type": "user_joined",
                 "user_id": user_id,
                 "username": username,
+                "current_artifact_id": None,
                 "timestamp": datetime.utcnow().isoformat()
             },
             exclude_user=user_id
@@ -127,58 +156,81 @@ class WebSocketManager:
             {
                 "type": "presence",
                 "users": room.get_users(),
-                "playbook_id": playbook_id
+                "project_id": project_id
             }
         )
 
-    async def disconnect(self, playbook_id: str, user_id: str):
+    async def disconnect(self, project_id: str, user_id: str):
         """
-        Disconnect a user from a playbook room
+        Disconnect a user from a project room
 
         Args:
-            playbook_id: The playbook to leave
+            project_id: The project to leave
             user_id: The user's ID
         """
-        if playbook_id not in self.rooms:
+        if project_id not in self.rooms:
             return
 
-        room = self.rooms[playbook_id]
+        room = self.rooms[project_id]
 
-        # Get username before removing
+        # Get user info before removing
         username = None
+        current_artifact_id = None
         if user_id in room.connections:
             username = room.connections[user_id].username
+            current_artifact_id = room.connections[user_id].current_artifact_id
 
         # Remove user from room
         room.remove_user(user_id)
 
+        # Snapshot trigger: last user on this artifact disconnected
+        if (
+            current_artifact_id
+            and room.users_on_artifact(current_artifact_id) == 0
+            and room.events_since_snapshot.get(current_artifact_id, 0) > 0
+        ):
+            logger.info(
+                "Last-user snapshot trigger for project=%s artifact=%s",
+                project_id, current_artifact_id,
+            )
+            room.events_since_snapshot[current_artifact_id] = 0
+            # Cancel inactivity timer if any
+            timer = room._inactivity_timers.pop(current_artifact_id, None)
+            if timer is not None:
+                timer.cancel()
+            if self._snapshot_callback:
+                asyncio.ensure_future(
+                    self._snapshot_callback(project_id, current_artifact_id)
+                )
+
         # Update user's rooms tracking
         if user_id in self.user_rooms:
-            self.user_rooms[user_id].discard(playbook_id)
+            self.user_rooms[user_id].discard(project_id)
             if not self.user_rooms[user_id]:
                 del self.user_rooms[user_id]
 
-        logger.info(f"User {username} ({user_id}) disconnected from playbook {playbook_id}")
+        logger.info(f"User {username} ({user_id}) disconnected from project {project_id}")
 
         # Clean up empty room
         if room.is_empty():
-            del self.rooms[playbook_id]
-            logger.info(f"Room {playbook_id} is now empty and removed")
+            del self.rooms[project_id]
+            logger.info(f"Room {project_id} is now empty and removed")
         else:
             # Notify others that user left
             await self.broadcast_to_room(
-                playbook_id,
+                project_id,
                 {
                     "type": "user_left",
                     "user_id": user_id,
                     "username": username,
+                    "current_artifact_id": current_artifact_id,
                     "timestamp": datetime.utcnow().isoformat()
                 }
             )
 
     async def broadcast_to_room(
         self,
-        playbook_id: str,
+        project_id: str,
         message: dict,
         exclude_user: Optional[str] = None
     ):
@@ -186,14 +238,14 @@ class WebSocketManager:
         Broadcast a message to all users in a room
 
         Args:
-            playbook_id: The playbook room
+            project_id: The project room
             message: The message to send
             exclude_user: Optional user_id to exclude from broadcast
         """
-        if playbook_id not in self.rooms:
+        if project_id not in self.rooms:
             return
 
-        room = self.rooms[playbook_id]
+        room = self.rooms[project_id]
         disconnected = []
 
         for user_id, conn in room.connections.items():
@@ -208,7 +260,7 @@ class WebSocketManager:
 
         # Clean up disconnected users
         for user_id in disconnected:
-            await self.disconnect(playbook_id, user_id)
+            await self.disconnect(project_id, user_id)
 
     async def send_personal(self, websocket: WebSocket, message: dict):
         """
@@ -225,77 +277,171 @@ class WebSocketManager:
 
     async def broadcast_update(
         self,
-        playbook_id: str,
+        project_id: str,
         user_id: str,
         username: str,
         update_type: str,
-        data: dict
+        data: dict,
+        artifact_id: Optional[str] = None
     ):
         """
-        Broadcast a playbook update to all users in the room
+        Broadcast a project update to all users in the room
 
         Args:
-            playbook_id: The playbook that was updated
+            project_id: The project that was updated
             user_id: The user who made the update
             username: The username for display
             update_type: Type of update (e.g., "content", "name", "task")
             data: The update data
+            artifact_id: Optional artifact ID for artifact-level updates
         """
+        message = {
+            "type": "update",
+            "update_type": update_type,
+            "user_id": user_id,
+            "username": username,
+            "data": data,
+            "timestamp": datetime.utcnow().isoformat()
+        }
+        if artifact_id is not None:
+            message["artifact_id"] = artifact_id
+
         await self.broadcast_to_room(
-            playbook_id,
-            {
-                "type": "update",
-                "update_type": update_type,
-                "user_id": user_id,
-                "username": username,
-                "data": data,
-                "timestamp": datetime.utcnow().isoformat()
-            },
+            project_id,
+            message,
             exclude_user=user_id
         )
 
-    def get_room_users(self, playbook_id: str) -> List[Dict]:
+    # ------------------------------------------------------------------
+    # Event-sourcing snapshot triggers
+    # ------------------------------------------------------------------
+
+    def record_event(self, project_id: str, artifact_id: str):
         """
-        Get list of users connected to a playbook
+        Track an incoming event for threshold-based snapshot and reset
+        the inactivity timer.
+        """
+        room = self.rooms.get(project_id)
+        if not room:
+            return
+
+        # Increment counter
+        room.events_since_snapshot[artifact_id] = (
+            room.events_since_snapshot.get(artifact_id, 0) + 1
+        )
+
+        # Reset inactivity timer
+        self._reset_inactivity_timer(project_id, artifact_id)
+
+        # Threshold check
+        if room.events_since_snapshot[artifact_id] >= self.EVENT_THRESHOLD:
+            room.events_since_snapshot[artifact_id] = 0
+            self._fire_snapshot(project_id, artifact_id)
+
+    def reset_event_counter(self, project_id: str, artifact_id: str):
+        """Reset the event counter after a snapshot is taken."""
+        room = self.rooms.get(project_id)
+        if room:
+            room.events_since_snapshot[artifact_id] = 0
+
+    def _reset_inactivity_timer(self, project_id: str, artifact_id: str):
+        """Cancel existing inactivity timer and start a new one."""
+        room = self.rooms.get(project_id)
+        if not room:
+            return
+
+        key = artifact_id
+        # Cancel previous timer
+        old = room._inactivity_timers.get(key)
+        if old is not None:
+            old.cancel()
+
+        loop = asyncio.get_event_loop()
+        handle = loop.call_later(
+            self.INACTIVITY_SECONDS,
+            lambda: asyncio.ensure_future(
+                self._on_inactivity(project_id, artifact_id)
+            ),
+        )
+        room._inactivity_timers[key] = handle
+
+    async def _on_inactivity(self, project_id: str, artifact_id: str):
+        """Fired after INACTIVITY_SECONDS without events."""
+        logger.info(
+            "Inactivity snapshot trigger for project=%s artifact=%s",
+            project_id, artifact_id,
+        )
+        self.reset_event_counter(project_id, artifact_id)
+        if self._snapshot_callback:
+            await self._snapshot_callback(project_id, artifact_id)
+
+    def _fire_snapshot(self, project_id: str, artifact_id: str):
+        """Schedule a snapshot callback (threshold trigger)."""
+        logger.info(
+            "Threshold snapshot trigger for project=%s artifact=%s",
+            project_id, artifact_id,
+        )
+        if self._snapshot_callback:
+            asyncio.ensure_future(
+                self._snapshot_callback(project_id, artifact_id)
+            )
+
+    def set_user_artifact(self, project_id: str, user_id: str, artifact_id: Optional[str]):
+        """
+        Set the current artifact a user is working on.
 
         Args:
-            playbook_id: The playbook ID
+            project_id: The project room
+            user_id: The user's ID
+            artifact_id: The artifact ID (or None to clear)
+        """
+        if project_id in self.rooms:
+            room = self.rooms[project_id]
+            if user_id in room.connections:
+                room.connections[user_id].current_artifact_id = artifact_id
+
+    def get_room_users(self, project_id: str) -> List[Dict]:
+        """
+        Get list of users connected to a project
+
+        Args:
+            project_id: The project ID
 
         Returns:
             List of connected users
         """
-        if playbook_id not in self.rooms:
+        if project_id not in self.rooms:
             return []
-        return self.rooms[playbook_id].get_users()
+        return self.rooms[project_id].get_users()
 
-    def get_user_count(self, playbook_id: str) -> int:
+    def get_user_count(self, project_id: str) -> int:
         """
-        Get number of users connected to a playbook
+        Get number of users connected to a project
 
         Args:
-            playbook_id: The playbook ID
+            project_id: The project ID
 
         Returns:
             Number of connected users
         """
-        if playbook_id not in self.rooms:
+        if project_id not in self.rooms:
             return 0
-        return len(self.rooms[playbook_id].connections)
+        return len(self.rooms[project_id].connections)
 
-    def is_user_connected(self, playbook_id: str, user_id: str) -> bool:
+    def is_user_connected(self, project_id: str, user_id: str) -> bool:
         """
-        Check if a user is connected to a playbook
+        Check if a user is connected to a project
 
         Args:
-            playbook_id: The playbook ID
+            project_id: The project ID
             user_id: The user ID
 
         Returns:
             True if user is connected
         """
-        if playbook_id not in self.rooms:
+        if project_id not in self.rooms:
             return False
-        return user_id in self.rooms[playbook_id].connections
+        return user_id in self.rooms[project_id].connections
 
 
 # Global instance

--- a/backend/app/version.py
+++ b/backend/app/version.py
@@ -3,7 +3,7 @@ Application version information
 """
 import os
 
-__version__ = "2.3.6"
+__version__ = "2.3.6-rc.2"
 __description__ = "Automation Factory API - Collaboration Bugfix"
 
 # Environment: PROD (default), STAGING, DEV

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -21,6 +21,7 @@ from app.models.project import Project
 from app.models.project_artifact import ProjectArtifact
 from app.models.project_collaboration import ProjectShare
 from app.models.git_credential import GitCredential
+from app.models.playbook_event import PlaybookEvent
 
 # ---------------------------------------------------------------------------
 # Database fixtures

--- a/backend/tests/test_event_sourcing_integration.py
+++ b/backend/tests/test_event_sourcing_integration.py
@@ -1,0 +1,236 @@
+"""
+Integration tests for event-sourcing: GET endpoint with events_delta,
+and WebSocket event_ack flow.
+"""
+
+import pytest
+import pytest_asyncio
+from unittest.mock import patch
+from sqlalchemy.ext.asyncio import async_sessionmaker, AsyncSession
+
+from app.core.security import create_access_token
+from app.models.playbook import Playbook
+from app.models.playbook_event import PlaybookEvent
+from app.models.project import Project
+from app.models.user import User
+
+
+def _make_token(user: User) -> str:
+    return create_access_token(data={"sub": user.id, "username": user.username})
+
+
+# ---------------------------------------------------------------------------
+# GET /api/playbooks/{id} — events_delta
+# ---------------------------------------------------------------------------
+
+class TestGetPlaybookEventsDelta:
+    """GET /api/playbooks/{id} returns events_delta since snapshot_sequence."""
+
+    @pytest.mark.asyncio
+    async def test_empty_events_delta(self, authenticated_client, test_playbook):
+        """When no events exist, events_delta is an empty list."""
+        resp = await authenticated_client.get(f"/api/playbooks/{test_playbook.id}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["events_delta"] == []
+        assert data["snapshot_sequence"] == 0
+
+    @pytest.mark.asyncio
+    async def test_events_delta_with_events(
+        self, authenticated_client, test_session, test_playbook, test_user
+    ):
+        """Events inserted after snapshot_sequence appear in events_delta."""
+        for i in range(1, 4):
+            test_session.add(PlaybookEvent(
+                playbook_id=test_playbook.id,
+                user_id=test_user.id,
+                event_type=f"action_{i}",
+                data={"step": i},
+                sequence_number=i,
+            ))
+        await test_session.commit()
+
+        resp = await authenticated_client.get(f"/api/playbooks/{test_playbook.id}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["events_delta"]) == 3
+        assert data["events_delta"][0]["sequence_number"] == 1
+        assert data["events_delta"][2]["sequence_number"] == 3
+
+    @pytest.mark.asyncio
+    async def test_events_delta_respects_snapshot_sequence(
+        self, authenticated_client, test_session, test_playbook, test_user
+    ):
+        """Only events after snapshot_sequence are returned."""
+        for i in range(1, 6):
+            test_session.add(PlaybookEvent(
+                playbook_id=test_playbook.id,
+                user_id=test_user.id,
+                event_type=f"action_{i}",
+                data={"step": i},
+                sequence_number=i,
+            ))
+        test_playbook.snapshot_sequence = 3
+        await test_session.commit()
+
+        resp = await authenticated_client.get(f"/api/playbooks/{test_playbook.id}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["snapshot_sequence"] == 3
+        assert len(data["events_delta"]) == 2
+        assert data["events_delta"][0]["sequence_number"] == 4
+        assert data["events_delta"][1]["sequence_number"] == 5
+
+
+# ---------------------------------------------------------------------------
+# WebSocket — event_ack on update with artifact_id
+# ---------------------------------------------------------------------------
+
+class TestWebSocketEventAck:
+    """WS update with artifact_id should persist event and return event_ack."""
+
+    @pytest_asyncio.fixture
+    async def project_with_playbook(self, test_session, test_user):
+        """Create a project with a playbook for WS testing."""
+        project = Project(
+            name="WS Test Project",
+            description="For WS event ack test",
+            owner_id=test_user.id,
+        )
+        test_session.add(project)
+        await test_session.commit()
+        await test_session.refresh(project)
+
+        playbook = Playbook(
+            name="WS Test Playbook",
+            content={"plays": []},
+            owner_id=test_user.id,
+            project_id=project.id,
+        )
+        test_session.add(playbook)
+        await test_session.commit()
+        await test_session.refresh(playbook)
+        return project, playbook
+
+    @pytest.mark.asyncio
+    async def test_update_with_artifact_returns_ack(
+        self, test_app, test_engine, test_user, project_with_playbook
+    ):
+        """Sending an update with artifact_id returns event_ack with sequence_number."""
+        from starlette.testclient import TestClient
+
+        project, playbook = project_with_playbook
+        token = _make_token(test_user)
+        factory = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+
+        with TestClient(test_app) as client:
+            with patch("app.api.endpoints.websocket.check_project_access_standalone", return_value="owner"), \
+                 patch("app.api.endpoints.websocket.AsyncSessionLocal", factory):
+                with client.websocket_connect(
+                    f"/ws/project/{project.id}?token={token}"
+                ) as ws:
+                    # Read initial messages: connected + presence
+                    msg1 = ws.receive_json()
+                    msg2 = ws.receive_json()
+                    types = {msg1["type"], msg2["type"]}
+                    assert "connected" in types
+                    assert "presence" in types
+
+                    # Set artifact
+                    ws.send_json({
+                        "type": "set_artifact",
+                        "artifact_id": playbook.id,
+                    })
+                    # Receive presence broadcast
+                    _pres = ws.receive_json()
+                    assert _pres["type"] == "presence"
+
+                    # Send update with artifact_id
+                    ws.send_json({
+                        "type": "update",
+                        "update_type": "content",
+                        "artifact_id": playbook.id,
+                        "event_type": "module_add",
+                        "data": {"module": "apt"},
+                    })
+
+                    # Should receive event_ack
+                    ack = ws.receive_json()
+                    assert ack["type"] == "event_ack"
+                    assert "sequence_number" in ack
+                    assert ack["sequence_number"] == 1
+
+    @pytest.mark.asyncio
+    async def test_update_without_artifact_returns_ack_no_sequence(
+        self, test_app, test_engine, test_user, project_with_playbook
+    ):
+        """Update without artifact_id returns event_ack but no sequence_number."""
+        from starlette.testclient import TestClient
+
+        project, playbook = project_with_playbook
+        token = _make_token(test_user)
+        factory = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+
+        with TestClient(test_app) as client:
+            with patch("app.api.endpoints.websocket.check_project_access_standalone", return_value="owner"), \
+                 patch("app.api.endpoints.websocket.AsyncSessionLocal", factory):
+                with client.websocket_connect(
+                    f"/ws/project/{project.id}?token={token}"
+                ) as ws:
+                    # Read initial messages
+                    ws.receive_json()  # connected or presence
+                    ws.receive_json()  # connected or presence
+
+                    # Send update WITHOUT artifact_id
+                    ws.send_json({
+                        "type": "update",
+                        "update_type": "content",
+                        "data": {"something": "else"},
+                    })
+
+                    # Should receive event_ack (no sequence_number)
+                    ack = ws.receive_json()
+                    assert ack["type"] == "event_ack"
+                    assert "sequence_number" not in ack
+
+    @pytest.mark.asyncio
+    async def test_successive_updates_increment_sequence(
+        self, test_app, test_engine, test_user, project_with_playbook
+    ):
+        """Two successive updates return incrementing sequence numbers."""
+        from starlette.testclient import TestClient
+
+        project, playbook = project_with_playbook
+        token = _make_token(test_user)
+        factory = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+
+        with TestClient(test_app) as client:
+            with patch("app.api.endpoints.websocket.check_project_access_standalone", return_value="owner"), \
+                 patch("app.api.endpoints.websocket.AsyncSessionLocal", factory):
+                with client.websocket_connect(
+                    f"/ws/project/{project.id}?token={token}"
+                ) as ws:
+                    ws.receive_json()  # connected or presence
+                    ws.receive_json()  # connected or presence
+
+                    # First update
+                    ws.send_json({
+                        "type": "update",
+                        "update_type": "content",
+                        "artifact_id": playbook.id,
+                        "event_type": "module_add",
+                        "data": {"step": 1},
+                    })
+                    ack1 = ws.receive_json()
+                    assert ack1["sequence_number"] == 1
+
+                    # Second update
+                    ws.send_json({
+                        "type": "update",
+                        "update_type": "content",
+                        "artifact_id": playbook.id,
+                        "event_type": "link_add",
+                        "data": {"step": 2},
+                    })
+                    ack2 = ws.receive_json()
+                    assert ack2["sequence_number"] == 2

--- a/backend/tests/test_playbook_event_model.py
+++ b/backend/tests/test_playbook_event_model.py
@@ -1,0 +1,152 @@
+"""
+Tests for PlaybookEvent model and Playbook.snapshot_sequence column.
+"""
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select, text
+
+from app.models.playbook_event import PlaybookEvent
+from app.models.playbook import Playbook
+
+
+# ---------------------------------------------------------------------------
+# PlaybookEvent model tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_create_playbook_event(test_session, test_playbook, test_user):
+    """A PlaybookEvent can be created and persisted."""
+    event = PlaybookEvent(
+        playbook_id=test_playbook.id,
+        user_id=test_user.id,
+        event_type="module_add",
+        data={"module": "apt", "position": {"x": 100, "y": 200}},
+        sequence_number=1,
+    )
+    test_session.add(event)
+    await test_session.commit()
+    await test_session.refresh(event)
+
+    assert event.id is not None
+    assert event.playbook_id == test_playbook.id
+    assert event.user_id == test_user.id
+    assert event.event_type == "module_add"
+    assert event.data["module"] == "apt"
+    assert event.sequence_number == 1
+    assert event.created_at is not None
+
+
+@pytest.mark.asyncio
+async def test_playbook_event_to_dict(test_session, test_playbook, test_user):
+    """to_dict returns all expected fields."""
+    event = PlaybookEvent(
+        playbook_id=test_playbook.id,
+        user_id=test_user.id,
+        event_type="link_delete",
+        data={"link_id": "abc-123"},
+        sequence_number=2,
+    )
+    test_session.add(event)
+    await test_session.commit()
+    await test_session.refresh(event)
+
+    d = event.to_dict()
+    assert set(d.keys()) == {
+        "id", "playbook_id", "user_id", "event_type",
+        "data", "sequence_number", "created_at",
+    }
+    assert d["event_type"] == "link_delete"
+    assert d["sequence_number"] == 2
+
+
+@pytest.mark.asyncio
+async def test_sequence_unique_per_playbook(test_session, test_playbook, test_user):
+    """Two events with the same (playbook_id, sequence_number) should conflict."""
+    e1 = PlaybookEvent(
+        playbook_id=test_playbook.id,
+        user_id=test_user.id,
+        event_type="play_update",
+        data={},
+        sequence_number=1,
+    )
+    e2 = PlaybookEvent(
+        playbook_id=test_playbook.id,
+        user_id=test_user.id,
+        event_type="module_add",
+        data={},
+        sequence_number=1,
+    )
+    test_session.add(e1)
+    await test_session.commit()
+
+    test_session.add(e2)
+    with pytest.raises(Exception):
+        await test_session.commit()
+    await test_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_multiple_events_ordered(test_session, test_playbook, test_user):
+    """Events can be queried in sequence order."""
+    for i in range(1, 4):
+        test_session.add(PlaybookEvent(
+            playbook_id=test_playbook.id,
+            user_id=test_user.id,
+            event_type=f"action_{i}",
+            data={"step": i},
+            sequence_number=i,
+        ))
+    await test_session.commit()
+
+    result = await test_session.execute(
+        select(PlaybookEvent)
+        .where(PlaybookEvent.playbook_id == test_playbook.id)
+        .order_by(PlaybookEvent.sequence_number)
+    )
+    events = result.scalars().all()
+    assert len(events) == 3
+    assert [e.sequence_number for e in events] == [1, 2, 3]
+
+
+@pytest.mark.asyncio
+async def test_event_nullable_user(test_session, test_playbook):
+    """user_id can be NULL (system-generated events)."""
+    event = PlaybookEvent(
+        playbook_id=test_playbook.id,
+        user_id=None,
+        event_type="system_snapshot",
+        data={},
+        sequence_number=1,
+    )
+    test_session.add(event)
+    await test_session.commit()
+    await test_session.refresh(event)
+    assert event.user_id is None
+
+
+# ---------------------------------------------------------------------------
+# Playbook.snapshot_sequence tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_playbook_snapshot_sequence_default(test_session, test_user):
+    """New playbooks have snapshot_sequence = 0 by default."""
+    pb = Playbook(
+        name="Fresh Playbook",
+        content={"plays": []},
+        owner_id=test_user.id,
+    )
+    test_session.add(pb)
+    await test_session.commit()
+    await test_session.refresh(pb)
+    assert pb.snapshot_sequence == 0
+
+
+@pytest.mark.asyncio
+async def test_playbook_snapshot_sequence_update(test_session, test_playbook):
+    """snapshot_sequence can be updated."""
+    test_playbook.snapshot_sequence = 42
+    await test_session.commit()
+    await test_session.refresh(test_playbook)
+    assert test_playbook.snapshot_sequence == 42

--- a/backend/tests/test_playbook_event_service.py
+++ b/backend/tests/test_playbook_event_service.py
@@ -1,0 +1,130 @@
+"""
+Tests for playbook_event_service.
+"""
+
+import pytest
+from sqlalchemy import select
+
+from app.services import playbook_event_service as svc
+from app.models.playbook_event import PlaybookEvent
+from app.models.playbook import Playbook
+
+
+# ---------------------------------------------------------------------------
+# get_next_sequence
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_next_sequence_empty(test_session, test_playbook):
+    """Returns 1 when no events exist."""
+    seq = await svc.get_next_sequence(test_playbook.id, test_session)
+    assert seq == 1
+
+
+@pytest.mark.asyncio
+async def test_get_next_sequence_after_events(test_session, test_playbook, test_user):
+    """Returns max + 1 after inserting events."""
+    for i in range(1, 4):
+        test_session.add(PlaybookEvent(
+            playbook_id=test_playbook.id,
+            user_id=test_user.id,
+            event_type="action",
+            data={},
+            sequence_number=i,
+        ))
+    await test_session.commit()
+
+    seq = await svc.get_next_sequence(test_playbook.id, test_session)
+    assert seq == 4
+
+
+# ---------------------------------------------------------------------------
+# save_event
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_save_event(test_session, test_playbook, test_user):
+    """save_event persists an event with auto sequence."""
+    event = await svc.save_event(
+        playbook_id=test_playbook.id,
+        user_id=test_user.id,
+        event_type="module_add",
+        data={"module": "apt"},
+        db=test_session,
+    )
+    await test_session.commit()
+
+    assert event.sequence_number == 1
+    assert event.event_type == "module_add"
+    assert event.data["module"] == "apt"
+
+
+@pytest.mark.asyncio
+async def test_save_event_increments(test_session, test_playbook, test_user):
+    """Successive save_event calls increment the sequence."""
+    e1 = await svc.save_event(test_playbook.id, test_user.id, "a", {}, test_session)
+    e2 = await svc.save_event(test_playbook.id, test_user.id, "b", {}, test_session)
+    await test_session.commit()
+
+    assert e1.sequence_number == 1
+    assert e2.sequence_number == 2
+
+
+# ---------------------------------------------------------------------------
+# get_events_since
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_events_since(test_session, test_playbook, test_user):
+    """Returns only events after the given sequence."""
+    for i in range(1, 6):
+        test_session.add(PlaybookEvent(
+            playbook_id=test_playbook.id,
+            user_id=test_user.id,
+            event_type=f"action_{i}",
+            data={},
+            sequence_number=i,
+        ))
+    await test_session.commit()
+
+    events = await svc.get_events_since(test_playbook.id, 3, test_session)
+    assert len(events) == 2
+    assert [e.sequence_number for e in events] == [4, 5]
+
+
+@pytest.mark.asyncio
+async def test_get_events_since_zero(test_session, test_playbook, test_user):
+    """since_sequence=0 returns all events."""
+    for i in range(1, 4):
+        test_session.add(PlaybookEvent(
+            playbook_id=test_playbook.id,
+            user_id=test_user.id,
+            event_type="x",
+            data={},
+            sequence_number=i,
+        ))
+    await test_session.commit()
+
+    events = await svc.get_events_since(test_playbook.id, 0, test_session)
+    assert len(events) == 3
+
+
+# ---------------------------------------------------------------------------
+# create_snapshot
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_create_snapshot(test_session, test_playbook):
+    """create_snapshot updates content and snapshot_sequence."""
+    new_content = {"plays": [{"name": "Play 1"}]}
+    pb = await svc.create_snapshot(
+        playbook_id=test_playbook.id,
+        content=new_content,
+        sequence_number=10,
+        db=test_session,
+    )
+    await test_session.commit()
+    await test_session.refresh(pb)
+
+    assert pb.content == new_content
+    assert pb.snapshot_sequence == 10

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "automation-factory-frontend",
   "private": true,
-  "version": "2.3.6",
+  "version": "2.3.6-rc.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/editor/PlaybookEditor.tsx
+++ b/frontend/src/components/editor/PlaybookEditor.tsx
@@ -13,9 +13,10 @@ import SystemZone from '../zones/SystemZone'
 
 interface PlaybookEditorProps {
   playbookId: string
+  artifactId?: string
 }
 
-const PlaybookEditor: React.FC<PlaybookEditorProps> = ({ playbookId }) => {
+const PlaybookEditor: React.FC<PlaybookEditorProps> = ({ playbookId, artifactId }) => {
   // Resize state for config and system panels
   const [systemZoneHeight, setSystemZoneHeight] = useState(200)
   const [configZoneWidth, setConfigZoneWidth] = useState(320)
@@ -32,7 +33,7 @@ const PlaybookEditor: React.FC<PlaybookEditorProps> = ({ playbookId }) => {
   const { loadPlaybook } = usePlaybookPersistence(playbookId)
 
   // Collaboration
-  const { connectToPlaybook, disconnectFromPlaybook, lastUpdate } = useCollaboration()
+  const { lastUpdate, isConnected, sendSetArtifact, connectedUsers, sendUpdate } = useCollaboration()
   const {
     sendModuleAdd,
     sendModuleMove,
@@ -40,6 +41,8 @@ const PlaybookEditor: React.FC<PlaybookEditorProps> = ({ playbookId }) => {
     sendModuleConfig,
     sendLinkAdd,
     sendLinkDelete,
+    sendPlayAdd,
+    sendPlayDelete,
     sendPlayUpdate,
     sendVariableAdd,
     sendVariableUpdate,
@@ -50,7 +53,7 @@ const PlaybookEditor: React.FC<PlaybookEditorProps> = ({ playbookId }) => {
     sendBlockCollapse,
     sendSectionCollapse,
     sendModuleResize,
-  } = useCollaborationSync()
+  } = useCollaborationSync({ artifactId })
 
   // Collaboration callbacks object
   const collaborationCallbacks: CollaborationCallbacks = {
@@ -61,6 +64,8 @@ const PlaybookEditor: React.FC<PlaybookEditorProps> = ({ playbookId }) => {
     sendModuleResize,
     sendLinkAdd,
     sendLinkDelete,
+    sendPlayAdd,
+    sendPlayDelete,
     sendPlayUpdate,
     sendVariableAdd,
     sendVariableUpdate,
@@ -70,13 +75,24 @@ const PlaybookEditor: React.FC<PlaybookEditorProps> = ({ playbookId }) => {
     sendRoleUpdate,
     sendBlockCollapse,
     sendSectionCollapse,
+    sendFullSync: () => {
+      if (!artifactId) return
+      const state = usePlaybookEditorStore.getState()
+      sendUpdate('full_sync', {
+        artifact_id: artifactId,
+        plays: state.plays as unknown as Record<string, unknown>[],
+        playbookName: state.playbookName,
+        collapsedBlocks: Array.from(state.collapsedBlocks),
+        collapsedBlockSections: Array.from(state.collapsedBlockSections),
+      } as unknown as Record<string, unknown>)
+    },
   }
 
   // Auto-load playbook
   const loadPlaybookRef = useRef(loadPlaybook)
   useEffect(() => { loadPlaybookRef.current = loadPlaybook })
   useEffect(() => {
-    if (playbookId && playbookId !== currentPlaybookId) {
+    if (playbookId) {
       loadPlaybookRef.current(playbookId)
     }
   }, [playbookId])
@@ -86,32 +102,62 @@ const PlaybookEditor: React.FC<PlaybookEditorProps> = ({ playbookId }) => {
   applyCollaborationUpdateRef.current = applyCollaborationUpdate
 
   useEffect(() => {
-    if (lastUpdate) {
-      console.log('[PlaybookEditor] Received collaboration update:', lastUpdate.update_type)
-      applyCollaborationUpdateRef.current(lastUpdate)
+    if (!lastUpdate) return
+
+    // Filter: only apply updates for this artifact (or updates without artifact_id for backward compat)
+    const updateArtifactId = lastUpdate.data?.artifact_id as string | undefined
+    if (artifactId && updateArtifactId && updateArtifactId !== artifactId) {
+      console.log('[PlaybookEditor] Ignoring update for different artifact:', updateArtifactId)
+      return
     }
-  }, [lastUpdate])
 
-  // Connect to playbook collaboration
-  const connectToPlaybookRef = useRef(connectToPlaybook)
-  const disconnectFromPlaybookRef = useRef(disconnectFromPlaybook)
+    // Handle full sync request: another user needs our current state
+    if (lastUpdate.update_type === 'request_full_sync') {
+      const state = usePlaybookEditorStore.getState()
+      const hasContent = state.plays.some(p => p.modules.filter(m => !m.isPlay).length > 0)
+      if (artifactId && state.currentPlaybookId && hasContent) {
+        console.log('[PlaybookEditor] Responding to request_full_sync')
+        sendUpdate('full_sync', {
+          artifact_id: artifactId,
+          plays: state.plays as unknown as Record<string, unknown>[],
+          playbookName: state.playbookName,
+          collapsedBlocks: Array.from(state.collapsedBlocks),
+          collapsedBlockSections: Array.from(state.collapsedBlockSections),
+        } as unknown as Record<string, unknown>)
+      }
+      return
+    }
+
+    console.log('[PlaybookEditor] Received collaboration update:', lastUpdate.update_type)
+    applyCollaborationUpdateRef.current(lastUpdate)
+  }, [lastUpdate, artifactId])
+
+  // Request full state sync from existing collaborators on this artifact (late joiner)
+  const hasSentSyncRequestRef = useRef<Record<string, boolean>>({})
+  useEffect(() => {
+    if (!artifactId || !isConnected) return
+    if (hasSentSyncRequestRef.current[artifactId]) return
+
+    const othersOnArtifact = connectedUsers.filter(u => u.current_artifact_id === artifactId)
+    if (othersOnArtifact.length > 0) {
+      hasSentSyncRequestRef.current[artifactId] = true
+      console.log('[PlaybookEditor] Sending request_full_sync for artifact:', artifactId)
+      sendUpdate('request_full_sync', { artifact_id: artifactId } as Record<string, unknown>)
+    }
+  }, [connectedUsers, artifactId, isConnected])
+
+  // Announce current artifact to other collaborators
+  const sendSetArtifactRef = useRef(sendSetArtifact)
+  useEffect(() => { sendSetArtifactRef.current = sendSetArtifact })
 
   useEffect(() => {
-    connectToPlaybookRef.current = connectToPlaybook
-    disconnectFromPlaybookRef.current = disconnectFromPlaybook
-  })
-
-  useEffect(() => {
-    console.log('[PlaybookEditor] currentPlaybookId changed to:', currentPlaybookId)
-    if (currentPlaybookId) {
-      console.log('[PlaybookEditor] Calling connectToPlaybook with:', currentPlaybookId)
-      connectToPlaybookRef.current(currentPlaybookId)
+    if (artifactId && isConnected) {
+      sendSetArtifactRef.current(artifactId)
     }
     return () => {
-      console.log('[PlaybookEditor] Cleanup - disconnecting from playbook')
-      disconnectFromPlaybookRef.current()
+      sendSetArtifactRef.current('')
     }
-  }, [currentPlaybookId])
+  }, [artifactId, isConnected])
 
   // Resize handlers
   const handleSystemMouseDown = () => setIsResizingSystem(true)
@@ -214,7 +260,7 @@ const PlaybookEditor: React.FC<PlaybookEditorProps> = ({ playbookId }) => {
             </Box>
             <ConfigZone
               onCollapse={() => setIsConfigCollapsed(true)}
-              collaborationCallbacks={{ sendModuleConfig, sendPlayUpdate }}
+              collaborationCallbacks={{ sendModuleConfig, sendPlayUpdate, sendModuleDelete }}
             />
           </Box>
         )}

--- a/frontend/src/components/zones/WorkZone.tsx
+++ b/frontend/src/components/zones/WorkZone.tsx
@@ -44,6 +44,8 @@ export interface CollaborationCallbacks {
   sendModuleResize?: (data: { moduleId: string; width: number; height: number; x: number; y: number }) => void
   sendLinkAdd?: (data: { link: Link }) => void
   sendLinkDelete?: (data: { linkId: string }) => void
+  sendPlayAdd?: (data: { play: Play }) => void
+  sendPlayDelete?: (data: { playId: string }) => void
   sendPlayUpdate?: (data: { playId: string; field: string; value: unknown }) => void
   sendVariableAdd?: (data: { playId: string; variable: PlayVariable }) => void
   sendVariableUpdate?: (data: { playId: string; variableIndex: number; variable: PlayVariable }) => void
@@ -53,6 +55,7 @@ export interface CollaborationCallbacks {
   sendRoleUpdate?: (data: { playId: string; roles: Array<string | { role: string; vars?: Record<string, unknown>; enabled?: boolean }> }) => void
   sendBlockCollapse?: (data: { blockId: string; collapsed: boolean }) => void
   sendSectionCollapse?: (data: { key: string; collapsed: boolean }) => void
+  sendFullSync?: () => void
 }
 
 interface WorkZoneProps {
@@ -261,15 +264,18 @@ const WorkZone = ({ collaborationCallbacks }: WorkZoneProps) => {
     }
     setPlays([...plays, newPlay])
     setActivePlayIndex(plays.length)
+    collaborationCallbacks?.sendPlayAdd?.({ play: newPlay })
   }
 
   const deletePlay = (index: number) => {
     if (plays.length === 1) return
+    const deletedPlayId = plays[index].id
     const newPlays = plays.filter((_, i) => i !== index)
     setPlays(newPlays)
     if (activePlayIndex >= newPlays.length) {
       setActivePlayIndex(newPlays.length - 1)
     }
+    collaborationCallbacks?.sendPlayDelete?.({ playId: deletedPlayId })
   }
 
   const updatePlayName = (index: number, newName: string) => {
@@ -284,6 +290,7 @@ const WorkZone = ({ collaborationCallbacks }: WorkZoneProps) => {
       }
       return updatedPlays
     })
+    collaborationCallbacks?.sendPlayUpdate?.({ playId: plays[index].id, field: 'name', value: newName })
   }
 
   // =====================================================
@@ -350,7 +357,8 @@ const WorkZone = ({ collaborationCallbacks }: WorkZoneProps) => {
       setPlaybookName(result.metadata.name)
     }
 
-    setCurrentPlaybookId(null)
+    // Notify collaborators of the imported content
+    collaborationCallbacks?.sendFullSync?.()
   }
 
   const deleteVariable = (index: number) => {

--- a/frontend/src/contexts/CollaborationContext.tsx
+++ b/frontend/src/contexts/CollaborationContext.tsx
@@ -1,27 +1,28 @@
 /**
  * Collaboration Context
  *
- * Provides real-time collaboration state for playbook editing.
+ * Provides real-time collaboration state for project editing.
  * Manages WebSocket connections, presence tracking, and update notifications.
  */
 
 import React, { createContext, useContext, useState, useCallback, useEffect, useRef, useMemo } from 'react'
-import { usePlaybookWebSocket, ConnectedUser, PlaybookUpdate } from '../hooks/usePlaybookWebSocket'
+import { useProjectWebSocket, ConnectedUser, ProjectUpdate } from '../hooks/useProjectWebSocket'
 import { useAuth } from './AuthContext'
 
 interface CollaborationContextType {
   // Connection state
   isConnected: boolean
   connectedUsers: ConnectedUser[]
-  currentPlaybookId: string | null
+  currentProjectId: string | null
 
   // Actions
-  connectToPlaybook: (playbookId: string) => void
-  disconnectFromPlaybook: () => void
+  connectToProject: (projectId: string) => void
+  disconnectFromProject: () => void
   sendUpdate: (updateType: string, data: Record<string, unknown>) => void
+  sendSetArtifact: (artifactId: string) => void
 
   // Update notifications
-  lastUpdate: PlaybookUpdate | null
+  lastUpdate: ProjectUpdate | null
   highlightedElement: string | null
   clearHighlight: () => void
 }
@@ -38,21 +39,21 @@ export const useCollaboration = () => {
 
 interface CollaborationProviderProps {
   children: React.ReactNode
-  onPlaybookUpdate?: (update: PlaybookUpdate) => void
+  onProjectUpdate?: (update: ProjectUpdate) => void
 }
 
 export const CollaborationProvider: React.FC<CollaborationProviderProps> = ({
   children,
-  onPlaybookUpdate
+  onProjectUpdate
 }) => {
   const { user } = useAuth()
-  const [currentPlaybookId, setCurrentPlaybookId] = useState<string | null>(null)
-  const [lastUpdate, setLastUpdate] = useState<PlaybookUpdate | null>(null)
+  const [currentProjectId, setCurrentProjectId] = useState<string | null>(null)
+  const [lastUpdate, setLastUpdate] = useState<ProjectUpdate | null>(null)
   const [highlightedElement, setHighlightedElement] = useState<string | null>(null)
   const highlightTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Handle incoming updates
-  const handleUpdate = useCallback((update: PlaybookUpdate) => {
+  const handleUpdate = useCallback((update: ProjectUpdate) => {
     setLastUpdate(update)
 
     // Set highlight for 2 seconds
@@ -71,8 +72,8 @@ export const CollaborationProvider: React.FC<CollaborationProviderProps> = ({
     }
 
     // Call external handler if provided
-    onPlaybookUpdate?.(update)
-  }, [onPlaybookUpdate])
+    onProjectUpdate?.(update)
+  }, [onProjectUpdate])
 
   // Handle presence changes
   const handlePresenceChange = useCallback((users: ConnectedUser[]) => {
@@ -84,9 +85,10 @@ export const CollaborationProvider: React.FC<CollaborationProviderProps> = ({
     isConnected,
     connectedUsers,
     sendUpdate,
+    sendSetArtifact,
     connect,
     disconnect
-  } = usePlaybookWebSocket(currentPlaybookId, {
+  } = useProjectWebSocket(currentProjectId, {
     onUpdate: handleUpdate,
     onPresenceChange: handlePresenceChange,
     autoReconnect: true
@@ -98,22 +100,22 @@ export const CollaborationProvider: React.FC<CollaborationProviderProps> = ({
     disconnectRef.current = disconnect
   })
 
-  // Connect to a playbook room - stable callback
-  const connectToPlaybook = useCallback((playbookId: string) => {
-    console.log('[Collab] connectToPlaybook called with:', playbookId)
-    setCurrentPlaybookId(prev => {
-      console.log('[Collab] setCurrentPlaybookId - prev:', prev, 'new:', playbookId)
-      if (playbookId !== prev) {
-        return playbookId
+  // Connect to a project room - stable callback
+  const connectToProject = useCallback((projectId: string) => {
+    console.log('[Collab] connectToProject called with:', projectId)
+    setCurrentProjectId(prev => {
+      console.log('[Collab] setCurrentProjectId - prev:', prev, 'new:', projectId)
+      if (projectId !== prev) {
+        return projectId
       }
       return prev
     })
   }, [])
 
-  // Disconnect from current playbook - stable callback
-  const disconnectFromPlaybook = useCallback(() => {
+  // Disconnect from current project - stable callback
+  const disconnectFromProject = useCallback(() => {
     disconnectRef.current()
-    setCurrentPlaybookId(null)
+    setCurrentProjectId(null)
     setLastUpdate(null)
     setHighlightedElement(null)
   }, [])
@@ -138,20 +140,22 @@ export const CollaborationProvider: React.FC<CollaborationProviderProps> = ({
   const value = useMemo<CollaborationContextType>(() => ({
     isConnected,
     connectedUsers,
-    currentPlaybookId,
-    connectToPlaybook,
-    disconnectFromPlaybook,
+    currentProjectId,
+    connectToProject,
+    disconnectFromProject,
     sendUpdate,
+    sendSetArtifact,
     lastUpdate,
     highlightedElement,
     clearHighlight
   }), [
     isConnected,
     connectedUsers,
-    currentPlaybookId,
-    connectToPlaybook,
-    disconnectFromPlaybook,
+    currentProjectId,
+    connectToProject,
+    disconnectFromProject,
     sendUpdate,
+    sendSetArtifact,
     lastUpdate,
     highlightedElement,
     clearHighlight

--- a/frontend/src/hooks/__tests__/usePlaybookPersistence.test.ts
+++ b/frontend/src/hooks/__tests__/usePlaybookPersistence.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+
+// --- Mocks ---
+
+const mockGetPlaybook = vi.fn()
+const mockListPlaybooks = vi.fn()
+
+vi.mock('../../services/playbookService', () => ({
+  playbookService: {
+    getPlaybook: (...args: unknown[]) => mockGetPlaybook(...args),
+    listPlaybooks: (...args: unknown[]) => mockListPlaybooks(...args),
+  },
+}))
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ isAuthenticated: true }),
+}))
+
+// Mock sessionStorage
+const sessionStore: Record<string, string> = {}
+vi.stubGlobal('sessionStorage', {
+  getItem: vi.fn((key: string) => sessionStore[key] || null),
+  setItem: vi.fn((key: string, value: string) => { sessionStore[key] = value }),
+  removeItem: vi.fn((key: string) => { delete sessionStore[key] }),
+  clear: vi.fn(() => { Object.keys(sessionStore).forEach(k => delete sessionStore[k]) }),
+})
+
+import { usePlaybookPersistence } from '../usePlaybookPersistence'
+import { usePlaybookEditorStore } from '../../stores/playbookEditorStore'
+
+// Helper: build a minimal playbook detail response
+function makePlaybookDetail(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'pb-1',
+    name: 'Test Playbook',
+    content: {
+      plays: [
+        {
+          id: 'play-1',
+          name: 'Play 1',
+          attributes: {
+            hosts: 'all',
+            gatherFacts: true,
+            become: false,
+            connection: 'ssh',
+            roles: [],
+          },
+        },
+      ],
+      modules: [
+        {
+          id: 'play-1-start-tasks',
+          collection: 'ansible.generic',
+          name: 'start',
+          description: 'Start point for tasks',
+          taskName: 'START',
+          x: 50,
+          y: 20,
+          isPlay: true,
+          parentSection: 'tasks',
+          playId: 'play-1',
+        },
+      ],
+      links: [],
+      variables: [],
+      collapsedBlocks: [],
+      collapsedBlockSections: [],
+    },
+    snapshot_sequence: 0,
+    events_delta: [],
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  Object.keys(sessionStore).forEach(k => delete sessionStore[k])
+  usePlaybookEditorStore.getState().resetStore()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('usePlaybookPersistence', () => {
+  describe('loadPlaybook — snapshot only', () => {
+    it('loads a playbook and calls loadPlaybookState on the store', async () => {
+      const detail = makePlaybookDetail()
+      mockGetPlaybook.mockResolvedValue(detail)
+
+      const { result } = renderHook(() => usePlaybookPersistence('pb-1'))
+
+      await act(async () => {
+        await result.current.loadPlaybook('pb-1')
+      })
+
+      const state = usePlaybookEditorStore.getState()
+      expect(state.currentPlaybookId).toBe('pb-1')
+      expect(state.playbookName).toBe('Test Playbook')
+      expect(mockGetPlaybook).toHaveBeenCalledWith('pb-1')
+    })
+  })
+
+  describe('loadPlaybook — snapshot + events_delta replay', () => {
+    it('replays events_delta via applyCollaborationUpdate after loading snapshot', async () => {
+      // Mock applyCollaborationUpdate to avoid real store logic on synthetic events
+      const mockApply = vi.fn()
+      const origApply = usePlaybookEditorStore.getState().applyCollaborationUpdate
+      usePlaybookEditorStore.setState({ applyCollaborationUpdate: mockApply })
+
+      const detail = makePlaybookDetail({
+        events_delta: [
+          {
+            id: 'evt-1',
+            playbook_id: 'pb-1',
+            user_id: 'u1',
+            event_type: 'module_add',
+            data: { moduleId: 'm-new', name: 'apt' },
+            sequence_number: 1,
+            created_at: '2026-03-18T10:00:00Z',
+          },
+          {
+            id: 'evt-2',
+            playbook_id: 'pb-1',
+            user_id: 'u2',
+            event_type: 'module_move',
+            data: { moduleId: 'm-new', x: 200, y: 300 },
+            sequence_number: 2,
+            created_at: '2026-03-18T10:01:00Z',
+          },
+        ],
+      })
+      mockGetPlaybook.mockResolvedValue(detail)
+
+      const { result } = renderHook(() => usePlaybookPersistence('pb-1'))
+
+      await act(async () => {
+        await result.current.loadPlaybook('pb-1')
+      })
+
+      expect(mockApply).toHaveBeenCalledTimes(2)
+
+      // First event
+      expect(mockApply).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        type: 'update',
+        update_type: 'module_add',
+        data: { moduleId: 'm-new', name: 'apt' },
+        user_id: 'u1',
+      }))
+
+      // Second event
+      expect(mockApply).toHaveBeenNthCalledWith(2, expect.objectContaining({
+        type: 'update',
+        update_type: 'module_move',
+        data: { moduleId: 'm-new', x: 200, y: 300 },
+        user_id: 'u2',
+      }))
+
+      usePlaybookEditorStore.setState({ applyCollaborationUpdate: origApply })
+    })
+
+    it('does not call applyCollaborationUpdate when events_delta is empty', async () => {
+      const mockApply = vi.fn()
+      const origApply = usePlaybookEditorStore.getState().applyCollaborationUpdate
+      usePlaybookEditorStore.setState({ applyCollaborationUpdate: mockApply })
+
+      mockGetPlaybook.mockResolvedValue(makePlaybookDetail({ events_delta: [] }))
+
+      const { result } = renderHook(() => usePlaybookPersistence('pb-1'))
+
+      await act(async () => {
+        await result.current.loadPlaybook('pb-1')
+      })
+
+      expect(mockApply).not.toHaveBeenCalled()
+      usePlaybookEditorStore.setState({ applyCollaborationUpdate: origApply })
+    })
+  })
+
+  describe('auto-save removal', () => {
+    it('does not return savePlaybook', () => {
+      mockListPlaybooks.mockResolvedValue([])
+
+      const { result } = renderHook(() => usePlaybookPersistence('pb-1'))
+
+      // savePlaybook should not exist in the return value
+      expect(result.current).not.toHaveProperty('savePlaybook')
+      expect(result.current).toHaveProperty('loadPlaybook')
+    })
+
+    it('does not auto-save on store state changes', async () => {
+      // Load a playbook first
+      mockGetPlaybook.mockResolvedValue(makePlaybookDetail())
+
+      const { result } = renderHook(() => usePlaybookPersistence('pb-1'))
+
+      await act(async () => {
+        await result.current.loadPlaybook('pb-1')
+      })
+
+      // Spy on playbookService to ensure no save calls happen
+      const updateSpy = vi.fn()
+      vi.spyOn(await import('../../services/playbookService'), 'playbookService', 'get').mockReturnValue({
+        getPlaybook: mockGetPlaybook,
+        listPlaybooks: mockListPlaybooks,
+        updatePlaybook: updateSpy,
+      } as any)
+
+      // Mutate the store
+      act(() => {
+        usePlaybookEditorStore.getState().setPlaybookName('Changed Name')
+      })
+
+      // Wait for any potential auto-save debounce (3s in the old code)
+      await act(async () => {
+        await new Promise(resolve => setTimeout(resolve, 4000))
+      })
+
+      // No backend save should have been triggered
+      expect(updateSpy).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/frontend/src/hooks/__tests__/useProjectWebSocket.test.ts
+++ b/frontend/src/hooks/__tests__/useProjectWebSocket.test.ts
@@ -1,0 +1,424 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+// --- Mock WebSocket ---
+
+let mockWsInstances: MockWebSocket[] = []
+
+class MockWebSocket {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
+
+  url: string
+  readyState: number = MockWebSocket.CONNECTING
+  onopen: ((ev: Event) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  send = vi.fn()
+  close = vi.fn((code?: number, reason?: string) => {
+    this.readyState = MockWebSocket.CLOSED
+    if (this.onclose) {
+      this.onclose({ code: code || 1000, reason: reason || '' } as CloseEvent)
+    }
+  })
+
+  constructor(url: string) {
+    this.url = url
+    mockWsInstances.push(this)
+  }
+
+  // Test helper: simulate server opening connection
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN
+    if (this.onopen) this.onopen(new Event('open'))
+  }
+
+  // Test helper: simulate incoming message
+  simulateMessage(data: Record<string, unknown>) {
+    if (this.onmessage) {
+      this.onmessage({ data: JSON.stringify(data) } as MessageEvent)
+    }
+  }
+
+  // Test helper: simulate close from server
+  simulateClose(code = 1006, reason = '') {
+    this.readyState = MockWebSocket.CLOSED
+    if (this.onclose) {
+      this.onclose({ code, reason } as CloseEvent)
+    }
+  }
+}
+
+// Install mock
+vi.stubGlobal('WebSocket', MockWebSocket)
+
+// Mock localStorage
+const mockStorage: Record<string, string> = {}
+vi.stubGlobal('localStorage', {
+  getItem: vi.fn((key: string) => mockStorage[key] || null),
+  setItem: vi.fn((key: string, value: string) => { mockStorage[key] = value }),
+  removeItem: vi.fn((key: string) => { delete mockStorage[key] }),
+  clear: vi.fn(() => { Object.keys(mockStorage).forEach(k => delete mockStorage[k]) }),
+})
+
+import { useProjectWebSocket, ProjectUpdate, ConnectedUser, EventAck } from '../useProjectWebSocket'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.useFakeTimers()
+  mockWsInstances = []
+  mockStorage['authToken'] = 'test-token-12345678901234567890'
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useProjectWebSocket', () => {
+  it('does not connect when projectId is null', () => {
+    renderHook(() => useProjectWebSocket(null))
+
+    expect(mockWsInstances).toHaveLength(0)
+  })
+
+  it('connects to /ws/project/{projectId} with auth token', () => {
+    renderHook(() => useProjectWebSocket('proj-123'))
+
+    expect(mockWsInstances).toHaveLength(1)
+    expect(mockWsInstances[0].url).toContain('/ws/project/proj-123')
+    expect(mockWsInstances[0].url).toContain('token=test-token-12345678901234567890')
+  })
+
+  it('does not connect when auth token is missing', () => {
+    delete mockStorage['authToken']
+
+    renderHook(() => useProjectWebSocket('proj-123'))
+
+    expect(mockWsInstances).toHaveLength(0)
+  })
+
+  it('sets isConnected to true on open', () => {
+    const { result } = renderHook(() => useProjectWebSocket('proj-123'))
+
+    expect(result.current.isConnected).toBe(false)
+
+    act(() => {
+      mockWsInstances[0].simulateOpen()
+    })
+
+    expect(result.current.isConnected).toBe(true)
+  })
+
+  it('starts ping interval on open', () => {
+    renderHook(() => useProjectWebSocket('proj-123'))
+
+    act(() => {
+      mockWsInstances[0].simulateOpen()
+    })
+
+    // Advance past one ping interval (25s)
+    act(() => {
+      vi.advanceTimersByTime(25000)
+    })
+
+    expect(mockWsInstances[0].send).toHaveBeenCalledWith(
+      expect.stringContaining('"type":"ping"')
+    )
+  })
+
+  it('parses presence message and updates connectedUsers', () => {
+    const onPresenceChange = vi.fn()
+    const { result } = renderHook(() =>
+      useProjectWebSocket('proj-123', { onPresenceChange })
+    )
+
+    act(() => {
+      mockWsInstances[0].simulateOpen()
+    })
+
+    const users: ConnectedUser[] = [
+      { user_id: 'u1', username: 'alice', connected_at: '2026-01-01T00:00:00Z' },
+      { user_id: 'u2', username: 'bob', connected_at: '2026-01-01T00:01:00Z' },
+    ]
+
+    act(() => {
+      mockWsInstances[0].simulateMessage({ type: 'presence', users })
+    })
+
+    expect(result.current.connectedUsers).toHaveLength(2)
+    expect(result.current.connectedUsers[0].username).toBe('alice')
+    expect(onPresenceChange).toHaveBeenCalledWith(users)
+  })
+
+  it('handles user_joined message', () => {
+    const { result } = renderHook(() => useProjectWebSocket('proj-123'))
+
+    act(() => {
+      mockWsInstances[0].simulateOpen()
+    })
+
+    act(() => {
+      mockWsInstances[0].simulateMessage({
+        type: 'user_joined',
+        user_id: 'u1',
+        username: 'alice',
+        timestamp: '2026-01-01T00:00:00Z',
+      })
+    })
+
+    expect(result.current.connectedUsers).toHaveLength(1)
+    expect(result.current.connectedUsers[0].username).toBe('alice')
+  })
+
+  it('handles user_left message', () => {
+    const { result } = renderHook(() => useProjectWebSocket('proj-123'))
+
+    act(() => {
+      mockWsInstances[0].simulateOpen()
+      mockWsInstances[0].simulateMessage({
+        type: 'presence',
+        users: [
+          { user_id: 'u1', username: 'alice', connected_at: '2026-01-01T00:00:00Z' },
+          { user_id: 'u2', username: 'bob', connected_at: '2026-01-01T00:01:00Z' },
+        ],
+      })
+    })
+
+    expect(result.current.connectedUsers).toHaveLength(2)
+
+    act(() => {
+      mockWsInstances[0].simulateMessage({
+        type: 'user_left',
+        user_id: 'u1',
+      })
+    })
+
+    expect(result.current.connectedUsers).toHaveLength(1)
+    expect(result.current.connectedUsers[0].username).toBe('bob')
+  })
+
+  it('parses update message and calls onUpdate', () => {
+    const onUpdate = vi.fn()
+    renderHook(() => useProjectWebSocket('proj-123', { onUpdate }))
+
+    act(() => {
+      mockWsInstances[0].simulateOpen()
+    })
+
+    const updateMsg = {
+      type: 'update',
+      update_type: 'module_add',
+      user_id: 'u1',
+      username: 'alice',
+      data: { moduleId: 'm1' },
+      timestamp: '2026-01-01T00:00:00Z',
+      artifact_id: 'art-1',
+    }
+
+    act(() => {
+      mockWsInstances[0].simulateMessage(updateMsg)
+    })
+
+    expect(onUpdate).toHaveBeenCalledTimes(1)
+    const received = onUpdate.mock.calls[0][0] as ProjectUpdate
+    expect(received.update_type).toBe('module_add')
+    expect(received.artifact_id).toBe('art-1')
+  })
+
+  it('includes artifact_id in ProjectUpdate type', () => {
+    // Type-level check: ProjectUpdate should accept artifact_id
+    const update: ProjectUpdate = {
+      type: 'update',
+      update_type: 'module_move',
+      user_id: 'u1',
+      username: 'alice',
+      data: {},
+      timestamp: '2026-01-01T00:00:00Z',
+      artifact_id: 'art-42',
+    }
+    expect(update.artifact_id).toBe('art-42')
+  })
+
+  it('sends update when WebSocket is open', () => {
+    const { result } = renderHook(() => useProjectWebSocket('proj-123'))
+
+    act(() => {
+      mockWsInstances[0].simulateOpen()
+    })
+
+    act(() => {
+      result.current.sendUpdate('module_move', { moduleId: 'm1', x: 100, y: 200 })
+    })
+
+    expect(mockWsInstances[0].send).toHaveBeenCalledWith(
+      JSON.stringify({
+        type: 'update',
+        update_type: 'module_move',
+        data: { moduleId: 'm1', x: 100, y: 200 },
+      })
+    )
+  })
+
+  it('does not send update when WebSocket is closed', () => {
+    const { result } = renderHook(() => useProjectWebSocket('proj-123'))
+
+    // Don't open the WebSocket
+    act(() => {
+      result.current.sendUpdate('module_move', { moduleId: 'm1' })
+    })
+
+    expect(mockWsInstances[0].send).not.toHaveBeenCalled()
+  })
+
+  it('attempts reconnection on non-clean close', () => {
+    renderHook(() =>
+      useProjectWebSocket('proj-123', { autoReconnect: true, reconnectInterval: 3000 })
+    )
+
+    act(() => {
+      mockWsInstances[0].simulateOpen()
+    })
+
+    const initialCount = mockWsInstances.length
+
+    // Simulate abnormal close (code 1006)
+    act(() => {
+      mockWsInstances[0].simulateClose(1006)
+    })
+
+    // Advance past reconnect interval
+    act(() => {
+      vi.advanceTimersByTime(3000)
+    })
+
+    // A new WebSocket should have been created
+    expect(mockWsInstances.length).toBeGreaterThan(initialCount)
+  })
+
+  it('does not reconnect on clean close (code 1000)', () => {
+    renderHook(() =>
+      useProjectWebSocket('proj-123', { autoReconnect: true })
+    )
+
+    act(() => {
+      mockWsInstances[0].simulateOpen()
+    })
+
+    const countBefore = mockWsInstances.length
+
+    // Simulate clean close
+    act(() => {
+      mockWsInstances[0].simulateClose(1000)
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(5000)
+    })
+
+    expect(mockWsInstances.length).toBe(countBefore)
+  })
+
+  it('disconnects and cleans up on unmount', () => {
+    const { unmount } = renderHook(() => useProjectWebSocket('proj-123'))
+
+    act(() => {
+      mockWsInstances[0].simulateOpen()
+    })
+
+    unmount()
+
+    expect(mockWsInstances[0].close).toHaveBeenCalled()
+  })
+
+  it('disconnects when projectId changes to null', () => {
+    const { rerender } = renderHook(
+      ({ id }) => useProjectWebSocket(id),
+      { initialProps: { id: 'proj-123' as string | null } }
+    )
+
+    act(() => {
+      mockWsInstances[0].simulateOpen()
+    })
+
+    rerender({ id: null })
+
+    expect(mockWsInstances[0].close).toHaveBeenCalled()
+  })
+
+  it('handles event_ack with sequence_number', () => {
+    const onEventAck = vi.fn()
+    const { result } = renderHook(() =>
+      useProjectWebSocket('proj-123', { onEventAck })
+    )
+
+    act(() => {
+      mockWsInstances[0].simulateOpen()
+    })
+
+    act(() => {
+      mockWsInstances[0].simulateMessage({ type: 'event_ack', sequence_number: 5 })
+    })
+
+    expect(onEventAck).toHaveBeenCalledTimes(1)
+    const received: EventAck = onEventAck.mock.calls[0][0]
+    expect(received.type).toBe('event_ack')
+    expect(received.sequence_number).toBe(5)
+    expect(result.current.lastSequenceNumber).toBe(5)
+  })
+
+  it('handles event_ack without sequence_number', () => {
+    const onEventAck = vi.fn()
+    const { result } = renderHook(() =>
+      useProjectWebSocket('proj-123', { onEventAck })
+    )
+
+    act(() => {
+      mockWsInstances[0].simulateOpen()
+    })
+
+    act(() => {
+      mockWsInstances[0].simulateMessage({ type: 'event_ack' })
+    })
+
+    expect(onEventAck).toHaveBeenCalledTimes(1)
+    expect(result.current.lastSequenceNumber).toBeNull()
+  })
+
+  it('resets lastSequenceNumber on disconnect', () => {
+    const { result } = renderHook(() => useProjectWebSocket('proj-123'))
+
+    act(() => {
+      mockWsInstances[0].simulateOpen()
+    })
+
+    // Set a sequence number via event_ack
+    act(() => {
+      mockWsInstances[0].simulateMessage({ type: 'event_ack', sequence_number: 3 })
+    })
+
+    expect(result.current.lastSequenceNumber).toBe(3)
+
+    // Disconnect
+    act(() => {
+      result.current.disconnect()
+    })
+
+    expect(result.current.lastSequenceNumber).toBeNull()
+  })
+
+  it('handles pong messages without error', () => {
+    renderHook(() => useProjectWebSocket('proj-123'))
+
+    act(() => {
+      mockWsInstances[0].simulateOpen()
+    })
+
+    // Should not throw
+    act(() => {
+      mockWsInstances[0].simulateMessage({ type: 'pong' })
+    })
+  })
+})

--- a/frontend/src/hooks/useCollaborationSync.ts
+++ b/frontend/src/hooks/useCollaborationSync.ts
@@ -24,8 +24,8 @@
 
 import { useCallback, useRef, useEffect } from 'react'
 import { useCollaboration } from '../contexts/CollaborationContext'
-import { PlaybookUpdate } from './usePlaybookWebSocket'
-import { ModuleBlock, Link, PlayVariable } from '../types/playbook'
+import { ProjectUpdate } from './useProjectWebSocket'
+import { ModuleBlock, Link, Play, PlayVariable } from '../types/playbook'
 
 // Debounce delay in milliseconds
 const DEBOUNCE_DELAY = 300
@@ -39,6 +39,8 @@ export type UpdateType =
   | 'module_resize'
   | 'link_add'
   | 'link_delete'
+  | 'play_add'
+  | 'play_delete'
   | 'play_update'
   | 'variable_add'
   | 'variable_update'
@@ -89,6 +91,14 @@ export interface LinkAddData {
 
 export interface LinkDeleteData {
   linkId: string
+}
+
+export interface PlayAddData {
+  play: Play
+}
+
+export interface PlayDeleteData {
+  playId: string
 }
 
 export interface PlayUpdateData {
@@ -147,6 +157,8 @@ export type UpdateData =
   | ModuleResizeData
   | LinkAddData
   | LinkDeleteData
+  | PlayAddData
+  | PlayDeleteData
   | PlayUpdateData
   | VariableAddData
   | VariableUpdateData
@@ -158,7 +170,7 @@ export type UpdateData =
   | SectionCollapseData
 
 // Handler type for applying updates
-export type UpdateHandler = (update: PlaybookUpdate) => void
+export type UpdateHandler = (update: ProjectUpdate) => void
 
 interface UseCollaborationSyncReturn {
   // Debounced update senders
@@ -169,6 +181,8 @@ interface UseCollaborationSyncReturn {
   sendModuleResize: (data: ModuleResizeData) => void
   sendLinkAdd: (data: LinkAddData) => void
   sendLinkDelete: (data: LinkDeleteData) => void
+  sendPlayAdd: (data: PlayAddData) => void
+  sendPlayDelete: (data: PlayDeleteData) => void
   sendPlayUpdate: (data: PlayUpdateData) => void
   sendVariableAdd: (data: VariableAddData) => void
   sendVariableUpdate: (data: VariableUpdateData) => void
@@ -186,8 +200,19 @@ interface UseCollaborationSyncReturn {
   isConnected: boolean
 }
 
-export function useCollaborationSync(): UseCollaborationSyncReturn {
+interface UseCollaborationSyncOptions {
+  artifactId?: string | null
+}
+
+export function useCollaborationSync(options: UseCollaborationSyncOptions = {}): UseCollaborationSyncReturn {
+  const { artifactId } = options
   const { sendUpdate: rawSendUpdate, isConnected } = useCollaboration()
+
+  // Wrap rawSendUpdate to inject artifact_id
+  const wrappedSendUpdate = useCallback((updateType: string, data: Record<string, unknown>) => {
+    const payload = artifactId ? { ...data, artifact_id: artifactId } : data
+    rawSendUpdate(updateType, payload)
+  }, [rawSendUpdate, artifactId])
 
   // Refs for debounce timers, keyed by update type + element id
   const debounceTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
@@ -216,18 +241,18 @@ export function useCollaborationSync(): UseCollaborationSyncReturn {
 
     // Set new timer
     const timer = setTimeout(() => {
-      rawSendUpdate(updateType, data as unknown as Record<string, unknown>)
+      wrappedSendUpdate(updateType, data as unknown as Record<string, unknown>)
       debounceTimersRef.current.delete(key)
     }, DEBOUNCE_DELAY)
 
     debounceTimersRef.current.set(key, timer)
-  }, [rawSendUpdate])
+  }, [wrappedSendUpdate])
 
   // Immediate send (no debounce) for discrete actions
   const immediateSend = useCallback((updateType: UpdateType, data: UpdateData) => {
     console.log('[CollabSync] immediateSend:', updateType, 'isConnected:', isConnected)
-    rawSendUpdate(updateType, data as unknown as Record<string, unknown>)
-  }, [rawSendUpdate, isConnected])
+    wrappedSendUpdate(updateType, data as unknown as Record<string, unknown>)
+  }, [wrappedSendUpdate, isConnected])
 
   // Typed send functions
   const sendModuleAdd = useCallback((data: ModuleAddData) => {
@@ -267,6 +292,16 @@ export function useCollaborationSync(): UseCollaborationSyncReturn {
   const sendLinkDelete = useCallback((data: LinkDeleteData) => {
     // Link delete is immediate
     immediateSend('link_delete', data)
+  }, [immediateSend])
+
+  const sendPlayAdd = useCallback((data: PlayAddData) => {
+    // Play add is immediate (discrete action)
+    immediateSend('play_add', data)
+  }, [immediateSend])
+
+  const sendPlayDelete = useCallback((data: PlayDeleteData) => {
+    // Play delete is immediate (discrete action)
+    immediateSend('play_delete', data)
   }, [immediateSend])
 
   const sendPlayUpdate = useCallback((data: PlayUpdateData) => {
@@ -320,6 +355,7 @@ export function useCollaborationSync(): UseCollaborationSyncReturn {
     const discreteTypes: UpdateType[] = [
       'module_add', 'module_delete', 'module_resize',
       'link_add', 'link_delete',
+      'play_add', 'play_delete',
       'variable_add', 'variable_delete',
       'role_add', 'role_delete', 'role_update',
       'block_collapse', 'section_collapse'
@@ -339,6 +375,8 @@ export function useCollaborationSync(): UseCollaborationSyncReturn {
     sendModuleResize,
     sendLinkAdd,
     sendLinkDelete,
+    sendPlayAdd,
+    sendPlayDelete,
     sendPlayUpdate,
     sendVariableAdd,
     sendVariableUpdate,
@@ -361,8 +399,8 @@ export function useCollaborationSync(): UseCollaborationSyncReturn {
  * is done in WorkZone's applyCollaborationUpdate function which has
  * access to the proper types and state setters.
  */
-export function applyPlaybookUpdate(
-  update: PlaybookUpdate,
+export function applyProjectUpdate(
+  update: ProjectUpdate,
   currentState: {
     modules: ModuleBlock[]
     links: Link[]

--- a/frontend/src/hooks/usePlaybookPersistence.ts
+++ b/frontend/src/hooks/usePlaybookPersistence.ts
@@ -3,6 +3,7 @@ import { usePlaybookEditorStore } from '../stores/playbookEditorStore'
 import { playbookService } from '../services/playbookService'
 import { useAuth } from '../contexts/AuthContext'
 import { Play } from '../types/playbook'
+import { ProjectUpdate } from './useProjectWebSocket'
 
 const PLAYBOOK_CACHE_KEY = 'automation-factory-playbook-cache'
 
@@ -32,8 +33,6 @@ const ensureStartModules = (playId: string, modules: any[]): any[] => {
 export const usePlaybookPersistence = (targetPlaybookId?: string) => {
   const { isAuthenticated } = useAuth()
   const hasRestoredFromCache = useRef(false)
-  const hasLoaded = useRef(false)
-  const autoSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const store = usePlaybookEditorStore
 
@@ -83,64 +82,25 @@ export const usePlaybookPersistence = (targetPlaybookId?: string) => {
     return unsub
   }, [saveToCache])
 
-  // Save playbook to backend
-  const savePlaybook = useCallback(async () => {
-    if (!isAuthenticated) {
-      console.log('Not authenticated, skipping save')
-      return
-    }
-
-    if (!hasLoaded.current) {
-      console.log('[Persistence] Skipping save — data not loaded yet')
-      return
-    }
-
-    const state = store.getState()
-
-    if (!state.currentPlaybookId) {
-      console.log('[Persistence] Skipping save — no playbook loaded')
-      return
-    }
-
-    state.setSaveStatus('saving')
-
-    try {
-      const content = state.serializePlaybookContent()
-
-      if (state.currentPlaybookId) {
-        await playbookService.updatePlaybook(state.currentPlaybookId, {
-          name: state.playbookName,
-          content,
-        })
-      } else {
-        const newPlaybook = await playbookService.createPlaybook({
-          name: state.playbookName,
-          content,
-        })
-        state.setCurrentPlaybookId(newPlaybook.id)
-      }
-
-      state.setSaveStatus('saved')
-      state.setLastSavedAt(new Date())
-
-      setTimeout(() => store.getState().setSaveStatus('idle'), 2000)
-    } catch (error) {
-      console.error('Failed to save playbook:', error)
-      store.getState().setSaveStatus('error')
-      setTimeout(() => store.getState().setSaveStatus('idle'), 3000)
-    }
-  }, [isAuthenticated])
-
   // Load a specific playbook by ID
   const loadPlaybook = useCallback(async (playbookId: string) => {
-    // Cancel any pending auto-save to prevent overwriting with stale state
-    if (autoSaveTimerRef.current) {
-      clearTimeout(autoSaveTimerRef.current)
-      autoSaveTimerRef.current = null
-    }
+    // Reset lastFullSyncAt so stale timestamps from a previous artifact don't
+    // trigger the race-condition guard for this load. Only a full_sync received
+    // *during* this load (timestamp > loadStartedAt) should block the update.
+    store.setState({ lastFullSyncAt: null })
+
+    const loadStartedAt = Date.now()
 
     try {
       const detailed = await playbookService.getPlaybook(playbookId)
+
+      // If a full_sync was applied while we were loading, don't overwrite the synced state
+      const { lastFullSyncAt } = store.getState()
+      if (lastFullSyncAt !== null && lastFullSyncAt > loadStartedAt) {
+        store.getState().setCurrentPlaybookId(detailed.id)
+        store.getState().setPlaybookName(detailed.name)
+        return
+      }
 
       const content = detailed.content
       let restoredPlays: Play[] = []
@@ -192,46 +152,27 @@ export const usePlaybookPersistence = (targetPlaybookId?: string) => {
         collapsedBlockSections: content.collapsedBlockSections,
       })
 
-      hasLoaded.current = true
+      // Replay event deltas on top of the snapshot
+      const eventsDelta = (detailed as any).events_delta
+      if (Array.isArray(eventsDelta) && eventsDelta.length > 0) {
+        const { applyCollaborationUpdate } = store.getState()
+        for (const event of eventsDelta) {
+          const update: ProjectUpdate = {
+            type: 'update',
+            update_type: event.event_type,
+            data: event.data || {},
+            user_id: event.user_id || '',
+            username: '',
+            timestamp: event.created_at || '',
+          }
+          applyCollaborationUpdate(update)
+        }
+        console.log(`[Persistence] Replayed ${eventsDelta.length} event(s) on top of snapshot`)
+      }
     } catch (error) {
       console.error('Failed to load playbook:', error)
     }
   }, [])
-
-  // Auto-save with debounce (only after data has been loaded)
-  // Filter out saveStatus/lastSavedAt changes to avoid save -> status change -> save loop
-  useEffect(() => {
-    if (!isAuthenticated) return
-
-    let prevSaveStatus = store.getState().saveStatus
-    let prevLastSavedAt = store.getState().lastSavedAt
-
-    const unsub = store.subscribe(() => {
-      if (!hasLoaded.current) return
-
-      const state = store.getState()
-      // Skip if only saveStatus or lastSavedAt changed (avoids infinite loop)
-      if (state.saveStatus !== prevSaveStatus || state.lastSavedAt !== prevLastSavedAt) {
-        prevSaveStatus = state.saveStatus
-        prevLastSavedAt = state.lastSavedAt
-        return
-      }
-
-      if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current)
-      autoSaveTimerRef.current = setTimeout(() => {
-        autoSaveTimerRef.current = null
-        savePlaybook()
-      }, 3000)
-    })
-
-    return () => {
-      unsub()
-      if (autoSaveTimerRef.current) {
-        clearTimeout(autoSaveTimerRef.current)
-        autoSaveTimerRef.current = null
-      }
-    }
-  }, [isAuthenticated, savePlaybook])
 
   // Load playbook on mount - try cache first for instant restore
   // Skip entirely when targetPlaybookId is provided: the caller handles loading explicitly
@@ -255,12 +196,6 @@ export const usePlaybookPersistence = (targetPlaybookId?: string) => {
           return false
         }
 
-        // Cancel any pending auto-save before restoring
-        if (autoSaveTimerRef.current) {
-          clearTimeout(autoSaveTimerRef.current)
-          autoSaveTimerRef.current = null
-        }
-
         console.log('[Persistence] Restoring playbook from cache:', cacheData.name)
         store.getState().loadPlaybookState({
           plays: cacheData.plays,
@@ -270,7 +205,6 @@ export const usePlaybookPersistence = (targetPlaybookId?: string) => {
           collapsedBlockSections: cacheData.collapsedBlockSections,
         })
         hasRestoredFromCache.current = true
-        hasLoaded.current = true
         return true
       } catch (e) {
         console.warn('[Persistence] Failed to restore from cache:', e)
@@ -295,5 +229,5 @@ export const usePlaybookPersistence = (targetPlaybookId?: string) => {
     loadLastPlaybook()
   }, [isAuthenticated, loadPlaybook])
 
-  return { savePlaybook, loadPlaybook }
+  return { loadPlaybook }
 }

--- a/frontend/src/hooks/useProjectWebSocket.ts
+++ b/frontend/src/hooks/useProjectWebSocket.ts
@@ -1,0 +1,333 @@
+/**
+ * WebSocket hook for real-time project collaboration
+ *
+ * Provides:
+ * - Connection management to project rooms
+ * - Real-time update notifications
+ * - Presence tracking (connected users)
+ * - Automatic reconnection
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+
+export interface ConnectedUser {
+  user_id: string
+  username: string
+  connected_at: string
+  current_artifact_id?: string
+}
+
+export interface ProjectUpdate {
+  type: 'update'
+  update_type: string
+  user_id: string
+  username: string
+  data: Record<string, unknown>
+  timestamp: string
+  artifact_id?: string
+}
+
+// Backward compatibility alias
+export type PlaybookUpdate = ProjectUpdate
+
+interface WebSocketMessage {
+  type: string
+  [key: string]: unknown
+}
+
+export interface EventAck {
+  type: 'event_ack'
+  sequence_number?: number
+}
+
+interface UseProjectWebSocketOptions {
+  onUpdate?: (update: ProjectUpdate) => void
+  onPresenceChange?: (users: ConnectedUser[]) => void
+  onEventAck?: (ack: EventAck) => void
+  autoReconnect?: boolean
+  reconnectInterval?: number
+}
+
+interface UseProjectWebSocketReturn {
+  isConnected: boolean
+  connectedUsers: ConnectedUser[]
+  lastSequenceNumber: number | null
+  sendUpdate: (updateType: string, data: Record<string, unknown>) => void
+  sendSetArtifact: (artifactId: string) => void
+  connect: () => void
+  disconnect: () => void
+}
+
+export function useProjectWebSocket(
+  projectId: string | null,
+  options: UseProjectWebSocketOptions = {}
+): UseProjectWebSocketReturn {
+  const {
+    onUpdate,
+    onPresenceChange,
+    onEventAck,
+    autoReconnect = true,
+    reconnectInterval = 3000
+  } = options
+
+  const [isConnected, setIsConnected] = useState(false)
+  const [connectedUsers, setConnectedUsers] = useState<ConnectedUser[]>([])
+  const [lastSequenceNumber, setLastSequenceNumber] = useState<number | null>(null)
+
+  const wsRef = useRef<WebSocket | null>(null)
+  const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const pingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  // Store options in refs to avoid dependency issues
+  const onUpdateRef = useRef(onUpdate)
+  const onPresenceChangeRef = useRef(onPresenceChange)
+  const onEventAckRef = useRef(onEventAck)
+  const autoReconnectRef = useRef(autoReconnect)
+  const reconnectIntervalRef = useRef(reconnectInterval)
+  const projectIdRef = useRef(projectId)
+
+  // Update refs when values change
+  useEffect(() => {
+    onUpdateRef.current = onUpdate
+    onPresenceChangeRef.current = onPresenceChange
+    onEventAckRef.current = onEventAck
+    autoReconnectRef.current = autoReconnect
+    reconnectIntervalRef.current = reconnectInterval
+    projectIdRef.current = projectId
+  })
+
+  // Get WebSocket URL from environment or derive from window location
+  const getWebSocketUrl = useCallback(() => {
+    const token = localStorage.getItem('authToken')
+    const currentProjectId = projectIdRef.current
+    console.log('[WS] getWebSocketUrl - token:', token ? 'exists' : 'MISSING', 'projectId:', currentProjectId)
+    if (!token || !currentProjectId) return null
+
+    // Use environment variable if available, otherwise derive from location
+    const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+    const wsHost = window.location.host
+    // Use runtime injection only — do NOT derive from pathname (would pick up route segments)
+    const wsBasePath = ((window as any).__BASE_PATH__ || '').replace(/\/$/, '')
+
+
+    const url = `${wsProtocol}//${wsHost}${wsBasePath}/ws/project/${currentProjectId}?token=${token.substring(0, 20)}...`
+    console.log('[WS] WebSocket URL:', url)
+    return `${wsProtocol}//${wsHost}${wsBasePath}/ws/project/${currentProjectId}?token=${token}`
+  }, [])
+
+  const handleMessage = useCallback((event: MessageEvent) => {
+    try {
+      const message: WebSocketMessage = JSON.parse(event.data)
+
+      switch (message.type) {
+        case 'presence':
+          const users = message.users as ConnectedUser[]
+          setConnectedUsers(users)
+          onPresenceChangeRef.current?.(users)
+          break
+
+        case 'user_joined':
+          setConnectedUsers(prev => {
+            const newUser: ConnectedUser = {
+              user_id: message.user_id as string,
+              username: message.username as string,
+              connected_at: message.timestamp as string
+            }
+            const updated = [...prev, newUser]
+            onPresenceChangeRef.current?.(updated)
+            return updated
+          })
+          break
+
+        case 'user_left':
+          setConnectedUsers(prev => {
+            const updated = prev.filter(u => u.user_id !== message.user_id)
+            onPresenceChangeRef.current?.(updated)
+            return updated
+          })
+          break
+
+        case 'artifact_update':
+          // A user changed their current artifact
+          setConnectedUsers(prev => {
+            const updated = prev.map(u =>
+              u.user_id === message.user_id
+                ? { ...u, current_artifact_id: (message.artifact_id as string) || undefined }
+                : u
+            )
+            onPresenceChangeRef.current?.(updated)
+            return updated
+          })
+          break
+
+        case 'update':
+          onUpdateRef.current?.(message as unknown as ProjectUpdate)
+          break
+
+        case 'event_ack': {
+          const ack: EventAck = {
+            type: 'event_ack',
+            sequence_number: message.sequence_number as number | undefined
+          }
+          if (ack.sequence_number != null) {
+            setLastSequenceNumber(ack.sequence_number)
+          }
+          onEventAckRef.current?.(ack)
+          break
+        }
+
+        case 'pong':
+          // Keep-alive response, no action needed
+          break
+
+        case 'connected':
+          // Initial connection confirmation with role info
+          console.log('[WS] Connected to project with role:', message.role)
+          break
+
+        case 'error':
+          console.error('WebSocket error:', message.message)
+          break
+
+        default:
+          console.warn('Unknown WebSocket message type:', message.type)
+      }
+    } catch (error) {
+      console.error('Failed to parse WebSocket message:', error)
+    }
+  }, [])
+
+  const connect = useCallback(() => {
+    const url = getWebSocketUrl()
+    if (!url) {
+      console.warn('Cannot connect: missing token or project ID')
+      return
+    }
+
+    // Close existing connection
+    if (wsRef.current) {
+      wsRef.current.close()
+    }
+
+    const ws = new WebSocket(url)
+    wsRef.current = ws
+
+    ws.onopen = () => {
+      console.log('WebSocket connected to project:', projectIdRef.current)
+      setIsConnected(true)
+
+      // Start ping interval
+      pingIntervalRef.current = setInterval(() => {
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: 'ping', timestamp: Date.now() }))
+        }
+      }, 25000) // Send ping every 25 seconds
+    }
+
+    ws.onmessage = handleMessage
+
+    ws.onclose = (event) => {
+      console.log('WebSocket closed:', event.code, event.reason)
+      setIsConnected(false)
+      setConnectedUsers([])
+
+      // Clear ping interval
+      if (pingIntervalRef.current) {
+        clearInterval(pingIntervalRef.current)
+        pingIntervalRef.current = null
+      }
+
+      // Auto reconnect if enabled and not a clean close or auth/access error
+      const noReconnectCodes = [1000, 4001, 4003]
+      if (autoReconnectRef.current && !noReconnectCodes.includes(event.code) && projectIdRef.current) {
+        reconnectTimeoutRef.current = setTimeout(() => {
+          console.log('Attempting to reconnect...')
+          connect()
+        }, reconnectIntervalRef.current)
+      }
+    }
+
+    ws.onerror = (error) => {
+      console.error('WebSocket error:', error)
+    }
+  }, [getWebSocketUrl, handleMessage])
+
+  const disconnect = useCallback(() => {
+    // Clear reconnect timeout
+    if (reconnectTimeoutRef.current) {
+      clearTimeout(reconnectTimeoutRef.current)
+      reconnectTimeoutRef.current = null
+    }
+
+    // Clear ping interval
+    if (pingIntervalRef.current) {
+      clearInterval(pingIntervalRef.current)
+      pingIntervalRef.current = null
+    }
+
+    // Close WebSocket
+    if (wsRef.current) {
+      wsRef.current.close(1000, 'User disconnected')
+      wsRef.current = null
+    }
+
+    setIsConnected(false)
+    setConnectedUsers([])
+    setLastSequenceNumber(null)
+  }, [])
+
+  const sendSetArtifact = useCallback((artifactId: string) => {
+    if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
+      const message = { type: 'set_artifact', artifact_id: artifactId }
+      console.log('[WS] Sending set_artifact:', artifactId || '(clear)')
+      wsRef.current.send(JSON.stringify(message))
+    }
+  }, [])
+
+  const sendUpdate = useCallback((updateType: string, data: Record<string, unknown>) => {
+    console.log('[WS] sendUpdate called:', updateType, 'wsRef:', wsRef.current ? 'exists' : 'null', 'readyState:', wsRef.current?.readyState)
+    if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
+      const message = {
+        type: 'update',
+        update_type: updateType,
+        data
+      }
+      console.log('[WS] Sending message:', JSON.stringify(message).substring(0, 200))
+      wsRef.current.send(JSON.stringify(message))
+    } else {
+      console.warn('[WS] WebSocket not connected, cannot send update. readyState:', wsRef.current?.readyState)
+    }
+  }, [])
+
+  // Connect when project ID changes
+  useEffect(() => {
+    console.log('[WS] useEffect triggered - projectId:', projectId)
+    if (projectId) {
+      console.log('[WS] Calling connect() for project:', projectId)
+      connect()
+    } else {
+      console.log('[WS] No projectId, calling disconnect()')
+      disconnect()
+    }
+
+    return () => {
+      console.log('[WS] Cleanup - calling disconnect()')
+      disconnect()
+    }
+  }, [projectId]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  return {
+    isConnected,
+    connectedUsers,
+    lastSequenceNumber,
+    sendUpdate,
+    sendSetArtifact,
+    connect,
+    disconnect
+  }
+}
+
+// Backward compatibility alias
+export const usePlaybookWebSocket = useProjectWebSocket
+
+export default useProjectWebSocket

--- a/frontend/src/stores/playbookEditorStore.ts
+++ b/frontend/src/stores/playbookEditorStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand'
 import { useShallow } from 'zustand/react/shallow'
 import { ModuleBlock, Link, PlayVariable, Play, PlayAttributes, ModuleSchema, VariableType, PlaySectionName } from '../types/playbook'
 import { PlaybookContent } from '../services/playbookService'
-import { PlaybookUpdate } from '../hooks/usePlaybookWebSocket'
+import { ProjectUpdate } from '../hooks/useProjectWebSocket'
 import { CustomTypeInfo } from '../utils/assertionsGenerator'
 
 // =====================================================
@@ -89,6 +89,7 @@ interface PlaybookEditorState {
   playbookName: string
   saveStatus: SaveStatus
   lastSavedAt: Date | null
+  lastFullSyncAt: number | null
 
   // UI state
   activeSectionTab: SectionTab
@@ -174,7 +175,8 @@ interface PlaybookEditorActions {
   }) => void
 
   // Collaboration
-  applyCollaborationUpdate: (update: PlaybookUpdate) => void
+  applyCollaborationUpdate: (update: ProjectUpdate) => void
+  applyFullSync: (data: { plays: Play[]; playbookName: string; collapsedBlocks: string[]; collapsedBlockSections: string[] }) => void
 
   // Reset
   resetStore: () => void
@@ -213,6 +215,7 @@ const initialState: PlaybookEditorState = {
   playbookName: 'Untitled Playbook',
   saveStatus: 'idle',
   lastSavedAt: null,
+  lastFullSyncAt: null,
   activeSectionTab: 'tasks',
   gridEnabled: false,
   draggedModuleId: null,
@@ -666,7 +669,7 @@ export const usePlaybookEditorStore = create<PlaybookEditorStore>((set, get) => 
   // Collaboration update handler
   // --------------------------------------------------
 
-  applyCollaborationUpdate: (update: PlaybookUpdate) => {
+  applyCollaborationUpdate: (update: ProjectUpdate) => {
     const { update_type, data, user_id } = update
 
     switch (update_type) {
@@ -830,6 +833,27 @@ export const usePlaybookEditorStore = create<PlaybookEditorStore>((set, get) => 
         break
       }
 
+      case 'play_add': {
+        const { play } = data as { play: Play }
+        set(state => ({
+          plays: [...state.plays, play],
+        }))
+        break
+      }
+
+      case 'play_delete': {
+        const { playId } = data as { playId: string }
+        set(state => {
+          if (state.plays.length <= 1) return state
+          const newPlays = state.plays.filter(p => p.id !== playId)
+          const newIndex = state.activePlayIndex >= newPlays.length
+            ? newPlays.length - 1
+            : state.activePlayIndex
+          return { plays: newPlays, activePlayIndex: newIndex }
+        })
+        break
+      }
+
       case 'play_update': {
         const { playId, field, value } = data as { playId: string; field: string; value: unknown }
         const attributeFields = ['hosts', 'remoteUser', 'connection', 'gatherFacts', 'become', 'roles']
@@ -838,6 +862,13 @@ export const usePlaybookEditorStore = create<PlaybookEditorStore>((set, get) => 
             if (p.id === playId) {
               if (attributeFields.includes(field)) {
                 return { ...p, attributes: { ...(p.attributes || {}), [field]: value } }
+              } else if (field === 'name') {
+                // Also update isPlay canvas modules so the tab AND canvas stay in sync
+                return {
+                  ...p,
+                  name: value as string,
+                  modules: p.modules.map(m => m.isPlay ? { ...m, taskName: value as string } : m),
+                }
               } else {
                 return { ...p, [field]: value }
               }
@@ -936,9 +967,30 @@ export const usePlaybookEditorStore = create<PlaybookEditorStore>((set, get) => 
         break
       }
 
+      case 'full_sync': {
+        const { plays, playbookName, collapsedBlocks, collapsedBlockSections } = data as {
+          plays: Play[]
+          playbookName: string
+          collapsedBlocks: string[]
+          collapsedBlockSections: string[]
+        }
+        get().applyFullSync({ plays, playbookName, collapsedBlocks, collapsedBlockSections })
+        break
+      }
+
       default:
         console.warn(`[PlaybookEditorStore] Unknown update type: ${update_type}`)
     }
+  },
+
+  applyFullSync: (data) => {
+    set({
+      plays: data.plays,
+      playbookName: data.playbookName,
+      collapsedBlocks: new Set(data.collapsedBlocks),
+      collapsedBlockSections: new Set(data.collapsedBlockSections),
+      lastFullSyncAt: Date.now(),
+    })
   },
 
   // --------------------------------------------------


### PR DESCRIPTION
## Summary
- Replace auto-save (snapshot every 3s) with individual event persistence via WebSocket
- Each user action is saved as a PlaybookEvent in DB with sequence_number before broadcasting
- Backend sends ACK with sequence_number to sender, then broadcasts to other collaborators
- Loading: GET /playbooks/{id} returns snapshot + events_delta, frontend replays delta
- Snapshot triggers: last WS disconnect, 60s inactivity, 500 events threshold

## Changes

### Backend
- **New model**: `PlaybookEvent` (playbook_events table)
- **New column**: `playbooks.snapshot_sequence` (with startup migration check)
- **New service**: `playbook_event_service` (save_event, get_events_since, create_snapshot, get_next_sequence)
- **Modified**: WS handler — persist event before broadcast, ACK sender with sequence_number
- **Modified**: GET `/api/playbooks/{id}` — returns events_delta since last snapshot

### Frontend
- **Modified**: `useProjectWebSocket` — handle `event_ack` messages
- **Modified**: `usePlaybookPersistence` — removed auto-save, added snapshot + delta replay loading
- **Modified**: `CollaborationContext`, `useCollaborationSync`, `playbookEditorStore`

## Tests
- Backend: 339 tests passing, 0 failures (3 new test files)
- Frontend: 25 new tests passing, TypeScript clean (2 new test files)
- 4 pre-existing test failures (unrelated: ProjectTree, AuthContext, ThemeContext, LoginPage)

## Code Review
APPROVED with non-blocking reserves:
1. 13 console.log in useProjectWebSocket.ts (cleanup before prod)
2. `as any` cast in usePlaybookPersistence.ts:156 (type debt)
3. get_next_sequence without explicit lock (protected by UNIQUE index + asyncio serialization)
4. datetime.utcnow deprecated in Python 3.12+ (pre-existing pattern)

## Version
v2.4.0 (new DB table = minor version bump)